### PR TITLE
Convert action_tests into a black box test

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -3,8 +3,10 @@ package action_test
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +72,8 @@ func mockBundle() *bundle.Bundle {
 			},
 		},
 		Actions: map[string]bundle.Action{
-			"test": {Modifies: true},
+			"test":        {Modifies: true},
+			"action_test": {Modifies: true},
 		},
 		Images: map[string]bundle.Image{
 			"image-a": {
@@ -83,160 +86,6 @@ func mockBundle() *bundle.Bundle {
 	}
 
 }
-
-// func TestOpFromClaim(t *testing.T) {
-// 	now := time.Now()
-// 	c := &claim.Claim{
-// 		Created:  now,
-// 		Modified: now,
-// 		Name:     "name",
-// 		Revision: "revision",
-// 		Bundle:   mockBundle(),
-// 		Parameters: map[string]interface{}{
-// 			"param_one":   "oneval",
-// 			"param_two":   "twoval",
-// 			"param_three": "threeval",
-// 		},
-// 	}
-// 	invocImage := c.Bundle.InvocationImages[0]
-//
-// 	op, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	is := assert.New(t)
-//
-// 	is.Equal(c.Name, op.Installation)
-// 	is.Equal(c.Revision, op.Revision)
-// 	is.Equal(invocImage.Image, op.Image)
-// 	is.Equal(driver.ImageTypeDocker, op.ImageType)
-// 	is.Equal(op.Environment["SECRET_ONE"], "I'm a secret")
-// 	is.Equal(op.Environment["PARAM_TWO"], "twoval")
-// 	is.Equal(op.Environment["CNAB_P_PARAM_ONE"], "oneval")
-// 	is.Equal(op.Files["/secret/two"], "I'm also a secret")
-// 	is.Equal(op.Files["/param/three"], "threeval")
-// 	is.Contains(op.Files, "/cnab/app/image-map.json")
-// 	var imgMap map[string]bundle.Image
-// 	is.NoError(json.Unmarshal([]byte(op.Files["/cnab/app/image-map.json"]), &imgMap))
-// 	is.Equal(c.Bundle.Images, imgMap)
-// 	is.Len(op.Parameters, 3)
-// 	is.Equal(os.Stdout, op.Out)
-// }
-//
-// func TestOpFromClaim_UndefinedParams(t *testing.T) {
-// 	now := time.Now()
-// 	c := &claim.Claim{
-// 		Created:  now,
-// 		Modified: now,
-// 		Name:     "name",
-// 		Revision: "revision",
-// 		Bundle:   mockBundle(),
-// 		Parameters: map[string]interface{}{
-// 			"param_one":         "oneval",
-// 			"param_two":         "twoval",
-// 			"param_three":       "threeval",
-// 			"param_one_million": "this is not a valid parameter",
-// 		},
-// 	}
-// 	invocImage := c.Bundle.InvocationImages[0]
-//
-// 	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.Error(t, err)
-// }
-//
-// func TestOpFromClaim_MissingRequiredParameter(t *testing.T) {
-// 	now := time.Now()
-// 	b := mockBundle()
-// 	b.Parameters["param_one"] = bundle.ParameterDefinition{Required: true}
-//
-// 	c := &claim.Claim{
-// 		Created:  now,
-// 		Modified: now,
-// 		Name:     "name",
-// 		Revision: "revision",
-// 		Bundle:   b,
-// 		Parameters: map[string]interface{}{
-// 			"param_two":   "twoval",
-// 			"param_three": "threeval",
-// 		},
-// 	}
-// 	invocImage := c.Bundle.InvocationImages[0]
-//
-// 	// missing required parameter fails
-// 	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.EqualError(t, err, `missing required parameter "param_one" for action "install"`)
-//
-// 	// fill the missing parameter
-// 	c.Parameters["param_one"] = "oneval"
-// 	_, err = opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.Nil(t, err)
-// }
-//
-// func TestOpFromClaim_MissingRequiredParamSpecificToAction(t *testing.T) {
-// 	now := time.Now()
-// 	b := mockBundle()
-// 	// Add a required parameter only defined for the test action
-// 	b.Parameters["param_test"] = bundle.ParameterDefinition{
-// 		ApplyTo:  []string{"test"},
-// 		Required: true,
-// 	}
-// 	c := &claim.Claim{
-// 		Created:  now,
-// 		Modified: now,
-// 		Name:     "name",
-// 		Revision: "revision",
-// 		Bundle:   b,
-// 		Parameters: map[string]interface{}{
-// 			"param_one":   "oneval",
-// 			"param_two":   "twoval",
-// 			"param_three": "threeval",
-// 		},
-// 	}
-// 	invocImage := c.Bundle.InvocationImages[0]
-//
-// 	// calling install action without the test required parameter for test action is ok
-// 	_, err := opFromClaim(claim.ActionInstall, stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.Nil(t, err)
-//
-// 	// test action needs the required parameter
-// 	_, err = opFromClaim("test", stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.EqualError(t, err, `missing required parameter "param_test" for action "test"`)
-//
-// 	c.Parameters["param_test"] = "only for test action"
-// 	_, err = opFromClaim("test", stateful, c, invocImage, mockSet, os.Stdout)
-// 	assert.Nil(t, err)
-// }
-//
-// func TestSelectInvocationImage_EmptyInvocationImages(t *testing.T) {
-// 	c := &claim.Claim{
-// 		Bundle: &bundle.Bundle{},
-// 	}
-// 	_, err := selectInvocationImage(&driver.DebugDriver{}, c)
-// 	if err == nil {
-// 		t.Fatal("expected an error")
-// 	}
-// 	want := "no invocationImages are defined"
-// 	got := err.Error()
-// 	if !strings.Contains(got, want) {
-// 		t.Fatalf("expected an error containing %q but got %q", want, got)
-// 	}
-// }
-//
-// func TestSelectInvocationImage_DriverIncompatible(t *testing.T) {
-// 	c := &claim.Claim{
-// 		Bundle: mockBundle(),
-// 	}
-// 	_, err := selectInvocationImage(&mockFailingDriver{}, c)
-// 	if err == nil {
-// 		t.Fatal("expected an error")
-// 	}
-// 	want := "driver is not compatible"
-// 	got := err.Error()
-// 	if !strings.Contains(got, want) {
-// 		t.Fatalf("expected an error containing %q but got %q", want, got)
-// 	}
-// }
 
 func testActionWithUndefinedParams(t *testing.T, inst action.Action) {
 	out := ioutil.Discard
@@ -308,4 +157,101 @@ func testOpFromClaim(t *testing.T, inst action.Action, spyDriver *spyDriver) {
 	is.Equal(c.Bundle.Images, imgMap)
 	is.Len(op.Parameters, 3)
 	is.Equal(out, op.Out)
+}
+
+func testOpFromClaimMissingRequiredParameter(t *testing.T, inst action.Action, actionName string) {
+	now := time.Now()
+	b := mockBundle()
+	b.Parameters["param_one"] = bundle.ParameterDefinition{Required: true}
+
+	c := &claim.Claim{
+		Created:  now,
+		Modified: now,
+		Name:     "name",
+		Revision: "revision",
+		Bundle:   b,
+		Parameters: map[string]interface{}{
+			"param_two":   "twoval",
+			"param_three": "threeval",
+		},
+	}
+
+	// missing required parameter fails
+	err := inst.Run(c, mockSet, os.Stdout)
+	assert.EqualError(t, err, fmt.Sprintf(`missing required parameter "param_one" for action "%s"`, actionName))
+
+	// fill the missing parameter
+	c.Parameters["param_one"] = "oneval"
+	err = inst.Run(c, mockSet, os.Stdout)
+	assert.Nil(t, err)
+}
+
+func testOpFromClaimMissingRequiredParamSpecificToAction(t *testing.T, inst action.Action) {
+	now := time.Now()
+	b := mockBundle()
+	// Add a required parameter only defined for the test action
+	b.Parameters["param_action_test"] = bundle.ParameterDefinition{
+		ApplyTo:  []string{"action_test"},
+		Required: true,
+	}
+	c := &claim.Claim{
+		Created:  now,
+		Modified: now,
+		Name:     "name",
+		Revision: "revision",
+		Bundle:   b,
+		Parameters: map[string]interface{}{
+			"param_one":   "oneval",
+			"param_two":   "twoval",
+			"param_three": "threeval",
+		},
+	}
+
+	// calling install action without the test required parameter for test action is ok
+	err := inst.Run(c, mockSet, os.Stdout)
+	assert.Nil(t, err)
+
+	// test action needs the required parameter
+	act := &action.RunCustom{
+		Driver: &spyDriver{},
+		Action: "action_test",
+	}
+	err = act.Run(c, mockSet, os.Stdout)
+	assert.EqualError(t, err, `missing required parameter "param_action_test" for action "action_test"`)
+
+	c.Parameters["param_action_test"] = "only for test action"
+	err = act.Run(c, mockSet, os.Stdout)
+	assert.Nil(t, err)
+}
+
+func testSelectInvocationImageEmptyInvocationImages(t *testing.T, inst action.Action) {
+	c := &claim.Claim{
+		Bundle: &bundle.Bundle{
+			Actions: map[string]bundle.Action{
+				"test": {Modifies: true},
+			},
+		},
+	}
+	err := inst.Run(c, mockSet, os.Stdout)
+	assert.NotNil(t, err)
+
+	want := "no invocationImages are defined"
+	got := err.Error()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected an error containing %q but got %q", want, got)
+	}
+}
+
+func testSelectInvocationImageDriverIncompatible(t *testing.T, inst action.Action) {
+	c := &claim.Claim{
+		Bundle: mockBundle(),
+	}
+	err := inst.Run(c, mockSet, os.Stdout)
+	assert.NotNil(t, err)
+
+	want := "driver is not compatible"
+	got := err.Error()
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected an error containing %q but got %q", want, got)
+	}
 }

--- a/action/install_test.go
+++ b/action/install_test.go
@@ -47,3 +47,23 @@ func TestInstallFromClaim(t *testing.T) {
 	inst := &action.Install{Driver: spyDriver}
 	testOpFromClaim(t, inst, spyDriver)
 }
+
+func TestInstall_FromClaimMissingRequiredParameter(t *testing.T) {
+	inst := &action.Install{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParameter(t, inst, "install")
+}
+
+func TestInstall_FromClaimMissingRequiredParamSpecificToAction(t *testing.T) {
+	inst := &action.Install{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParamSpecificToAction(t, inst)
+}
+
+func TestInstall_SelectInvocationImageEmptyInvocationImages(t *testing.T) {
+	inst := &action.Install{Driver: &spyDriver{}}
+	testSelectInvocationImageEmptyInvocationImages(t, inst)
+}
+
+func TestInstall_SelectInvocationImageDriverIncompatible(t *testing.T) {
+	inst := &action.Install{Driver: &mockFailingDriver{}}
+	testSelectInvocationImageDriverIncompatible(t, inst)
+}

--- a/action/install_test.go
+++ b/action/install_test.go
@@ -1,10 +1,11 @@
-package action
+package action_test
 
 import (
 	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // makes sure Install implements Action interface
-var _ Action = &Install{}
+var _ action.Action = &action.Install{}
 
 func TestInstall_Run(t *testing.T) {
 	out := ioutil.Discard
@@ -26,12 +27,17 @@ func TestInstall_Run(t *testing.T) {
 		Parameters: map[string]interface{}{},
 	}
 
-	inst := &Install{Driver: &driver.DebugDriver{}}
+	inst := &action.Install{Driver: &driver.DebugDriver{}}
 	assert.NoError(t, inst.Run(c, mockSet, out))
 
-	inst = &Install{Driver: &mockFailingDriver{}}
+	inst = &action.Install{Driver: &mockFailingDriver{}}
 	assert.Error(t, inst.Run(c, mockSet, out))
 
-	inst = &Install{Driver: &mockFailingDriver{shouldHandle: true}}
+	inst = &action.Install{Driver: &mockFailingDriver{shouldHandle: true}}
 	assert.Error(t, inst.Run(c, mockSet, out))
+}
+
+func TestInstall_WithUndefinedParams(t *testing.T) {
+	inst := &action.Install{Driver: &mockFailingDriver{}}
+	testActionWithUndefinedParams(t, inst)
 }

--- a/action/install_test.go
+++ b/action/install_test.go
@@ -41,3 +41,9 @@ func TestInstall_WithUndefinedParams(t *testing.T) {
 	inst := &action.Install{Driver: &mockFailingDriver{}}
 	testActionWithUndefinedParams(t, inst)
 }
+
+func TestInstallFromClaim(t *testing.T) {
+	spyDriver := &spyDriver{}
+	inst := &action.Install{Driver: spyDriver}
+	testOpFromClaim(t, inst, spyDriver)
+}

--- a/action/run_custom_test.go
+++ b/action/run_custom_test.go
@@ -1,25 +1,26 @@
-package action
+package action_test
 
 import (
 	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
+	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
 
-	"github.com/deislabs/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 )
 
 // makes sure RunCustom implements Action interface
-var _ Action = &RunCustom{}
+var _ action.Action = &action.RunCustom{}
 
 func TestRunCustom(t *testing.T) {
 	out := ioutil.Discard
 	is := assert.New(t)
 
-	rc := &RunCustom{
+	rc := &action.RunCustom{
 		Driver: &driver.DebugDriver{},
 		Action: "test",
 	}
@@ -48,4 +49,12 @@ func TestRunCustom(t *testing.T) {
 	if err := rc.Run(c, mockSet, out); err == nil {
 		t.Fatal("Unknown action should fail")
 	}
+}
+
+func TestRunCustom_WithUndefinedParams(t *testing.T) {
+	rc := &action.RunCustom{
+		Driver: &driver.DebugDriver{},
+		Action: "test",
+	}
+	testActionWithUndefinedParams(t, rc)
 }

--- a/action/run_custom_test.go
+++ b/action/run_custom_test.go
@@ -59,11 +59,43 @@ func TestRunCustom_WithUndefinedParams(t *testing.T) {
 	testActionWithUndefinedParams(t, rc)
 }
 
-func TestRunCustomFromClaim(t *testing.T) {
+func TestRunCustom_FromClaim(t *testing.T) {
 	spyDriver := &spyDriver{}
 	rc := &action.RunCustom{
 		Driver: spyDriver,
 		Action: "test",
 	}
 	testOpFromClaim(t, rc, spyDriver)
+}
+
+func TestRunCustom_FromClaimMissingRequiredParameter(t *testing.T) {
+	rc := &action.RunCustom{
+		Driver: &spyDriver{},
+		Action: "test",
+	}
+	testOpFromClaimMissingRequiredParameter(t, rc, "test")
+}
+
+func TestRunCustom_FromClaimMissingRequiredParamSpecificToAction(t *testing.T) {
+	rc := &action.RunCustom{
+		Driver: &spyDriver{},
+		Action: "test",
+	}
+	testOpFromClaimMissingRequiredParamSpecificToAction(t, rc)
+}
+
+func TestRunCustom_SelectInvocationImageEmptyInvocationImages(t *testing.T) {
+	rc := &action.RunCustom{
+		Driver: &spyDriver{},
+		Action: "test",
+	}
+	testSelectInvocationImageEmptyInvocationImages(t, rc)
+}
+
+func TestRunCustom_SelectInvocationImageDriverIncompatible(t *testing.T) {
+	rc := &action.RunCustom{
+		Driver: &mockFailingDriver{},
+		Action: "test",
+	}
+	testSelectInvocationImageDriverIncompatible(t, rc)
 }

--- a/action/run_custom_test.go
+++ b/action/run_custom_test.go
@@ -58,3 +58,12 @@ func TestRunCustom_WithUndefinedParams(t *testing.T) {
 	}
 	testActionWithUndefinedParams(t, rc)
 }
+
+func TestRunCustomFromClaim(t *testing.T) {
+	spyDriver := &spyDriver{}
+	rc := &action.RunCustom{
+		Driver: spyDriver,
+		Action: "test",
+	}
+	testOpFromClaim(t, rc, spyDriver)
+}

--- a/action/status_test.go
+++ b/action/status_test.go
@@ -1,10 +1,11 @@
-package action
+package action_test
 
 import (
 	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
 
@@ -12,12 +13,12 @@ import (
 )
 
 // makes sure Status implements Action interface
-var _ Action = &Status{}
+var _ action.Action = &action.Status{}
 
 func TestStatus_Run(t *testing.T) {
 	out := ioutil.Discard
 
-	st := &Status{Driver: &driver.DebugDriver{}}
+	st := &action.Status{Driver: &driver.DebugDriver{}}
 	c := &claim.Claim{
 		Created:    time.Time{},
 		Modified:   time.Time{},
@@ -31,6 +32,11 @@ func TestStatus_Run(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st = &Status{Driver: &mockFailingDriver{}}
+	st = &action.Status{Driver: &mockFailingDriver{}}
 	assert.Error(t, st.Run(c, mockSet, out))
+}
+
+func TestStatus_WithUndefinedParams(t *testing.T) {
+	inst := &action.Status{Driver: &mockFailingDriver{}}
+	testActionWithUndefinedParams(t, inst)
 }

--- a/action/status_test.go
+++ b/action/status_test.go
@@ -41,8 +41,28 @@ func TestStatus_WithUndefinedParams(t *testing.T) {
 	testActionWithUndefinedParams(t, inst)
 }
 
-func TestStatusFromClaim(t *testing.T) {
+func TestStatus_FromClaim(t *testing.T) {
 	spyDriver := &spyDriver{}
 	rc := &action.Status{Driver: spyDriver}
 	testOpFromClaim(t, rc, spyDriver)
+}
+
+func TestStatus_FromClaimMissingRequiredParameter(t *testing.T) {
+	inst := &action.Status{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParameter(t, inst, "status")
+}
+
+func TestStatus_FromClaimMissingRequiredParamSpecificToAction(t *testing.T) {
+	inst := &action.Status{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParamSpecificToAction(t, inst)
+}
+
+func TestStatus_SelectInvocationImageEmptyInvocationImages(t *testing.T) {
+	inst := &action.Status{Driver: &spyDriver{}}
+	testSelectInvocationImageEmptyInvocationImages(t, inst)
+}
+
+func TestStatus_SelectInvocationImageDriverIncompatible(t *testing.T) {
+	inst := &action.Status{Driver: &mockFailingDriver{}}
+	testSelectInvocationImageDriverIncompatible(t, inst)
 }

--- a/action/status_test.go
+++ b/action/status_test.go
@@ -40,3 +40,9 @@ func TestStatus_WithUndefinedParams(t *testing.T) {
 	inst := &action.Status{Driver: &mockFailingDriver{}}
 	testActionWithUndefinedParams(t, inst)
 }
+
+func TestStatusFromClaim(t *testing.T) {
+	spyDriver := &spyDriver{}
+	rc := &action.Status{Driver: spyDriver}
+	testOpFromClaim(t, rc, spyDriver)
+}

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -63,3 +63,9 @@ func TestUninstall_WithUndefinedParams(t *testing.T) {
 	inst := &action.Uninstall{Driver: &mockFailingDriver{}}
 	testActionWithUndefinedParams(t, inst)
 }
+
+func TestUninstallFromClaim(t *testing.T) {
+	spyDriver := &spyDriver{}
+	rc := &action.Uninstall{Driver: spyDriver}
+	testOpFromClaim(t, rc, spyDriver)
+}

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -58,7 +58,6 @@ func TestUninstall_Run(t *testing.T) {
 	}
 }
 
-
 func TestUninstall_WithUndefinedParams(t *testing.T) {
 	inst := &action.Uninstall{Driver: &mockFailingDriver{}}
 	testActionWithUndefinedParams(t, inst)
@@ -68,4 +67,24 @@ func TestUninstallFromClaim(t *testing.T) {
 	spyDriver := &spyDriver{}
 	rc := &action.Uninstall{Driver: spyDriver}
 	testOpFromClaim(t, rc, spyDriver)
+}
+
+func TestUninstall_FromClaimMissingRequiredParameter(t *testing.T) {
+	inst := &action.Uninstall{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParameter(t, inst, "uninstall")
+}
+
+func TestUninstall_FromClaimMissingRequiredParamSpecificToAction(t *testing.T) {
+	inst := &action.Uninstall{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParamSpecificToAction(t, inst)
+}
+
+func TestUnintall_SelectInvocationImageEmptyInvocationImages(t *testing.T) {
+	inst := &action.Uninstall{Driver: &spyDriver{}}
+	testSelectInvocationImageEmptyInvocationImages(t, inst)
+}
+
+func TestUninstall_SelectInvocationImageDriverIncompatible(t *testing.T) {
+	inst := &action.Uninstall{Driver: &mockFailingDriver{}}
+	testSelectInvocationImageDriverIncompatible(t, inst)
 }

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -1,10 +1,11 @@
-package action
+package action_test
 
 import (
 	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // makes sure Uninstall implements Action interface
-var _ Action = &Uninstall{}
+var _ action.Action = &action.Uninstall{}
 
 func TestUninstall_Run(t *testing.T) {
 	out := ioutil.Discard
@@ -26,7 +27,7 @@ func TestUninstall_Run(t *testing.T) {
 		Parameters: map[string]interface{}{},
 	}
 
-	uninst := &Uninstall{Driver: &driver.DebugDriver{}}
+	uninst := &action.Uninstall{Driver: &driver.DebugDriver{}}
 	assert.NoError(t, uninst.Run(c, mockSet, out))
 	if c.Created == c.Modified {
 		t.Error("Claim was not updated with modified time stamp during uninstallafter uninstall action")
@@ -39,10 +40,10 @@ func TestUninstall_Run(t *testing.T) {
 		t.Errorf("Claim result status not successfully updated. Expected %v, got %v", claim.StatusSuccess, c.Result.Status)
 	}
 
-	uninst = &Uninstall{Driver: &mockFailingDriver{}}
+	uninst = &action.Uninstall{Driver: &mockFailingDriver{}}
 	assert.Error(t, uninst.Run(c, mockSet, out))
 
-	uninst = &Uninstall{Driver: &mockFailingDriver{shouldHandle: true}}
+	uninst = &action.Uninstall{Driver: &mockFailingDriver{shouldHandle: true}}
 	assert.Error(t, uninst.Run(c, mockSet, out))
 	if c.Result.Message == "" {
 		t.Error("Expected error message in claim result message")
@@ -55,4 +56,10 @@ func TestUninstall_Run(t *testing.T) {
 	if c.Result.Status != claim.StatusFailure {
 		t.Errorf("Expected claim result status to be %v, got %v", claim.StatusFailure, c.Result.Status)
 	}
+}
+
+
+func TestUninstall_WithUndefinedParams(t *testing.T) {
+	inst := &action.Uninstall{Driver: &mockFailingDriver{}}
+	testActionWithUndefinedParams(t, inst)
 }

--- a/action/upgrade_test.go
+++ b/action/upgrade_test.go
@@ -63,8 +63,28 @@ func TestUpgrade_WithUndefinedParams(t *testing.T) {
 	testActionWithUndefinedParams(t, inst)
 }
 
-func TestUpgradeFromClaim(t *testing.T) {
+func TestUpgrade_FromClaim(t *testing.T) {
 	spyDriver := &spyDriver{}
 	rc := &action.Upgrade{Driver: spyDriver}
 	testOpFromClaim(t, rc, spyDriver)
+}
+
+func TestUpgrade_FromClaimMissingRequiredParameter(t *testing.T) {
+	inst := &action.Upgrade{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParameter(t, inst, "upgrade")
+}
+
+func TestUpgrade_FromClaimMissingRequiredParamSpecificToAction(t *testing.T) {
+	inst := &action.Upgrade{Driver: &spyDriver{}}
+	testOpFromClaimMissingRequiredParamSpecificToAction(t, inst)
+}
+
+func TestUpgrade_SelectInvocationImageEmptyInvocationImages(t *testing.T) {
+	inst := &action.Upgrade{Driver: &spyDriver{}}
+	testSelectInvocationImageEmptyInvocationImages(t, inst)
+}
+
+func TestUpgrade_SelectInvocationImageDriverIncompatible(t *testing.T) {
+	inst := &action.Upgrade{Driver: &mockFailingDriver{}}
+	testSelectInvocationImageDriverIncompatible(t, inst)
 }

--- a/action/upgrade_test.go
+++ b/action/upgrade_test.go
@@ -62,3 +62,9 @@ func TestUpgrade_WithUndefinedParams(t *testing.T) {
 	inst := &action.Upgrade{Driver: &mockFailingDriver{}}
 	testActionWithUndefinedParams(t, inst)
 }
+
+func TestUpgradeFromClaim(t *testing.T) {
+	spyDriver := &spyDriver{}
+	rc := &action.Upgrade{Driver: spyDriver}
+	testOpFromClaim(t, rc, spyDriver)
+}

--- a/action/upgrade_test.go
+++ b/action/upgrade_test.go
@@ -1,10 +1,11 @@
-package action
+package action_test
 
 import (
 	"io/ioutil"
 	"testing"
 	"time"
 
+	"github.com/deislabs/cnab-go/action"
 	"github.com/deislabs/cnab-go/claim"
 	"github.com/deislabs/cnab-go/driver"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // makes sure Upgrade implements Action interface
-var _ Action = &Upgrade{}
+var _ action.Action = &action.Upgrade{}
 
 func TestUpgrade_Run(t *testing.T) {
 	out := ioutil.Discard
@@ -26,7 +27,7 @@ func TestUpgrade_Run(t *testing.T) {
 		Parameters: map[string]interface{}{},
 	}
 
-	upgr := &Upgrade{Driver: &driver.DebugDriver{}}
+	upgr := &action.Upgrade{Driver: &driver.DebugDriver{}}
 	assert.NoError(t, upgr.Run(c, mockSet, out))
 	if c.Created == c.Modified {
 		t.Error("Claim was not updated with modified time stamp during upgrade action")
@@ -39,10 +40,10 @@ func TestUpgrade_Run(t *testing.T) {
 		t.Errorf("Claim result status not successfully updated. Expected %v, got %v", claim.StatusSuccess, c.Result.Status)
 	}
 
-	upgr = &Upgrade{Driver: &mockFailingDriver{}}
+	upgr = &action.Upgrade{Driver: &mockFailingDriver{}}
 	assert.Error(t, upgr.Run(c, mockSet, out))
 
-	upgr = &Upgrade{Driver: &mockFailingDriver{shouldHandle: true}}
+	upgr = &action.Upgrade{Driver: &mockFailingDriver{shouldHandle: true}}
 	assert.Error(t, upgr.Run(c, mockSet, out))
 	if c.Result.Message == "" {
 		t.Error("Expected error message in claim result message")
@@ -55,4 +56,9 @@ func TestUpgrade_Run(t *testing.T) {
 	if c.Result.Status != claim.StatusFailure {
 		t.Errorf("Expected claim result status to be %v, got %v", claim.StatusFailure, c.Result.Status)
 	}
+}
+
+func TestUpgrade_WithUndefinedParams(t *testing.T) {
+	inst := &action.Upgrade{Driver: &mockFailingDriver{}}
+	testActionWithUndefinedParams(t, inst)
 }


### PR DESCRIPTION
Play around with the idea of keeping the action tests by creating the tests in `action_test.go` and than call these tests for each command.

What y'all think about this idea?
These shared methods in action look very meaty so they should have some tests, but they will be all the same between action. This way we can reuse the tests between action

fixes #10 