### PR TITLE
Proposal: refactor Operation API

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -98,15 +98,33 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 	env["CNAB_BUNDLE_NAME"] = c.Bundle.Name
 	env["CNAB_BUNDLE_VERSION"] = c.Bundle.Version
 
+	envSlice := make([]driver.EnvVar, len(env))
+	i := 0
+	for k, v := range env {
+		envSlice[i] = driver.EnvVar{
+			Name:  k,
+			Value: v,
+		}
+		i++
+	}
+	fileSlice := make([]driver.File, len(env))
+	j := 0
+	for k, v := range files {
+		fileSlice[j] = driver.File{
+			Path:    k,
+			Content: []byte(v),
+		}
+		j++
+	}
+
 	return &driver.Operation{
 		Action:       action,
 		Installation: c.Name,
-		Parameters:   c.Parameters,
 		Image:        ii.Image,
 		ImageType:    ii.ImageType,
 		Revision:     c.Revision,
-		Environment:  env,
-		Files:        files,
+		Environment:  envSlice,
+		Files:        fileSlice,
 		Out:          w,
 	}, nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -23,8 +23,6 @@ type Operation struct {
 	Revision string `json:"revision"`
 	// Action is the action to be performed
 	Action string `json:"action"`
-	// Parameters are the parameters to be injected into the container
-	Parameters map[string]interface{} `json:"parameters"`
 	// Image is the invocation image
 	Image string `json:"image"`
 	// ImageType is the type of image.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -38,17 +38,17 @@ type Operation struct {
 // EnvVar represents an environment variable set in the invocation image.
 type EnvVar struct {
 	// Name of the environment variable.
-	Name string
+	Name string `json:"name"`
 	// Value of the environment variable.
-	Value string
+	Value string `json:"value"`
 }
 
 // A File represents the path and file content injected in the invocation image.
 type File struct {
 	// Path of the file, eg. /cnab/app/nginx.conf
-	Path string
+	Path string `json:"path"`
 	// File content
-	Bytes []byte
+	Content []byte `json:"content"`
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -29,12 +29,28 @@ type Operation struct {
 	Image string `json:"image"`
 	// ImageType is the type of image.
 	ImageType string `json:"image_type"`
-	// Environment contains environment variables that should be injected into the invocation image
-	Environment map[string]string `json:"environment"`
+	// Environment contains environment variables that should be set in the invocation image
+	Environment []EnvVar `json:"environment"`
 	// Files contains files that should be injected into the invocation image.
-	Files map[string]string `json:"files"`
+	Files []File `json:"files"`
 	// Output stream for log messages from the driver
 	Out io.Writer `json:"-"`
+}
+
+// EnvVar represents an environment variable set in the invocation image.
+type EnvVar struct {
+	// Name of the environment variable.
+	Name string
+	// Value of the environment variable.
+	Value string
+}
+
+// A File represents the path and file content injected in the invocation image.
+type File struct {
+	// Path of the file, eg. /cnab/app/nginx.conf
+	Path string
+	// File content
+	Bytes []byte
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -38,19 +38,24 @@ func TestOperation_Unmarshall(t *testing.T) {
 	expectedOp := Operation{
 		Action:       "install",
 		Installation: "test",
-		Parameters: map[string]interface{}{
-			"param1": "value1",
-			"param2": "value2",
+		Image:        "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+		ImageType:    "docker",
+		Revision:     "01DDY0MT808KX0GGZ6SMXN4TW",
+		Environment: []EnvVar{
+			{
+				Name:  "ENV1",
+				Value: "value1",
+			},
+			{
+				Name:  "ENV2",
+				Value: "value2",
+			},
 		},
-		Image:     "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
-		ImageType: "docker",
-		Revision:  "01DDY0MT808KX0GGZ6SMXN4TW",
-		Environment: map[string]string{
-			"ENV1": "value1",
-			"ENV2": "value2",
-		},
-		Files: map[string]string{
-			"/cnab/app/image-map.json": "{}",
+		Files: []File{
+			{
+				Path:    "/cnab/app/image-map.json",
+				Content: []byte("{}"),
+			},
 		},
 	}
 	var op Operation
@@ -66,19 +71,24 @@ func TestOperation_Marshall(t *testing.T) {
 	actualOp := Operation{
 		Action:       "install",
 		Installation: "test",
-		Parameters: map[string]interface{}{
-			"param1": "value1",
-			"param2": "value2",
+		Image:        "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+		ImageType:    "docker",
+		Revision:     "01DDY0MT808KX0GGZ6SMXN4TW",
+		Environment: []EnvVar{
+			{
+				Name:  "ENV1",
+				Value: "value1",
+			},
+			{
+				Name:  "ENV2",
+				Value: "value2",
+			},
 		},
-		Image:     "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
-		ImageType: "docker",
-		Revision:  "01DDY0MT808KX0GGZ6SMXN4TW",
-		Environment: map[string]string{
-			"ENV1": "value1",
-			"ENV2": "value2",
-		},
-		Files: map[string]string{
-			"/cnab/app/image-map.json": "{}",
+		Files: []File{
+			{
+				Path:    "/cnab/app/image-map.json",
+				Content: []byte("{}"),
+			},
 		},
 		Out: os.Stdout,
 	}

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -30,8 +30,11 @@ func TestDriver_Run_Integration(t *testing.T) {
 				Installation: "example",
 				Action:       "install",
 				Image:        "cnab/helloworld@sha256:55f83710272990efab4e076f9281453e136980becfd879640b06552ead751284",
-				Environment: map[string]string{
-					"PORT": "3000",
+				Environment: []driver.EnvVar{
+					{
+						Name:  "PORT",
+						Value: "3000",
+					},
 				},
 			},
 			output: "Port parameter was set to 3000\nInstall action\nAction install complete for example\n",
@@ -44,10 +47,19 @@ func TestDriver_Run_Integration(t *testing.T) {
 			var output bytes.Buffer
 			tc.op.Out = &output
 			if tc.op.Environment == nil {
-				tc.op.Environment = map[string]string{}
+				tc.op.Environment = []driver.EnvVar{}
 			}
-			tc.op.Environment["CNAB_ACTION"] = tc.op.Action
-			tc.op.Environment["CNAB_INSTALLATION_NAME"] = tc.op.Installation
+			tc.op.Environment = append(
+				tc.op.Environment,
+				driver.EnvVar{
+					Name:  "CNAB_ACTION",
+					Value: tc.op.Action,
+				},
+				driver.EnvVar{
+					Name:  "CNAB_INSTALLATION_NAME",
+					Value: tc.op.Installation,
+				},
+			)
 
 			err := k.Run(tc.op)
 

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -24,8 +24,11 @@ func TestDriver_Run(t *testing.T) {
 	op := driver.Operation{
 		Action: "install",
 		Out:    os.Stdout,
-		Environment: map[string]string{
-			"foo": "bar",
+		Environment: []driver.EnvVar{
+			{
+				Name:  "foo",
+				Value: "bar",
+			},
 		},
 	}
 

--- a/testdata/operations/valid-operation.json
+++ b/testdata/operations/valid-operation.json
@@ -1,18 +1,23 @@
 {
-    "installation_name": "test",
-    "revision": "01DDY0MT808KX0GGZ6SMXN4TW",
-    "action": "install",
-    "parameters": {
-        "param1": "value1",
-        "param2": "value2"
+  "installation_name": "test",
+  "revision": "01DDY0MT808KX0GGZ6SMXN4TW",
+  "action": "install",
+  "image": "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+  "image_type": "docker",
+  "environment": [
+    {
+      "name": "ENV1",
+      "value": "value1"
     },
-    "image": "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
-    "image_type": "docker",
-    "environment": {
-        "ENV1": "value1",
-        "ENV2": "value2"
-    },
-    "files": {
-        "/cnab/app/image-map.json": "{}"
+    {
+      "name": "ENV2",
+      "value": "value2"
     }
+  ],
+  "files": [
+    {
+      "path": "/cnab/app/image-map.json",
+      "content": "e30="
+    }
+  ]
 }


### PR DESCRIPTION
This PR introduces two new types, `EnvVar` and `File`. IMO this change helps make how to correctly use these objects more clear to end users of the public API.

This is similar to how [Container.Env](https://github.com/kubernetes/kubernetes/blob/c7972d9a5e7f555371fec7a3237f08ebc1ae9d7c/pkg/apis/core/types.go#L2030) is defined in kubernetes.

I've also removed `Parameters`, as I _think_ those should not be required here (they are already represented as environment variables and/or files).