### PR TITLE
WIP: Introduce a digest validation interface and docker implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -443,6 +443,30 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:e28d2af83f2a3d11795fead0d5842edbacf97b756d06ddb1da2c3aee73c5c118"
+  name = "github.com/google/go-containerregistry"
+  packages = [
+    "pkg/authn",
+    "pkg/internal/retry",
+    "pkg/logs",
+    "pkg/name",
+    "pkg/v1",
+    "pkg/v1/daemon",
+    "pkg/v1/empty",
+    "pkg/v1/layout",
+    "pkg/v1/partial",
+    "pkg/v1/random",
+    "pkg/v1/remote",
+    "pkg/v1/remote/transport",
+    "pkg/v1/tarball",
+    "pkg/v1/types",
+    "pkg/v1/v1util",
+  ]
+  pruneopts = "NUT"
+  revision = "31e00cede111067bae48bfc2cbfc522b0b36207f"
+
+[[projects]]
   digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -631,6 +655,17 @@
   pruneopts = "NUT"
   revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
   version = "v3.0.0"
+
+[[projects]]
+  digest = "1:c059b65022f1dc90449dd08389f1bc5f78cd48e0bed682bc7e9ae96cda591694"
+  name = "github.com/pivotal/image-relocation"
+  packages = [
+    "pkg/image",
+    "pkg/registry",
+  ]
+  pruneopts = "NUT"
+  revision = "ea07ec0b5a8a8e6fb53e33d479fa557bd5faa023"
+  version = "v0.2"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
@@ -1169,6 +1204,8 @@
     "github.com/docker/go/canonical/json",
     "github.com/globalsign/mgo",
     "github.com/oklog/ulid",
+    "github.com/pivotal/image-relocation/pkg/image",
+    "github.com/pivotal/image-relocation/pkg/registry",
     "github.com/pkg/errors",
     "github.com/qri-io/jsonschema",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,10 @@
   name = "github.com/docker/cli"
   revision = "f95ca8e1ba6c22c9abcdbf65e8dcc39c53958bba"
 
+[[constraint]]
+  name = "github.com/pivotal/image-relocation"
+  version = "v0.2"
+
 [[override]]
   name = "github.com/docker/docker"
   revision = "f76d6a078d881f410c00e8d900dcdfc2e026c841"

--- a/digests/validation.go
+++ b/digests/validation.go
@@ -1,0 +1,45 @@
+package digests
+
+import (
+	"fmt"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/digests/validators"
+	"github.com/pkg/errors"
+)
+
+// Validator validates that the contentDigest for each provided image matches
+// the authoritative source. By default, validation will fail if a contentDigest
+// is not provided for the image. Set allowMissingDigests to true to allow this
+type Validator interface {
+	Validate(images []bundle.Image, allowMissingDigests bool) error
+}
+
+type validator struct {
+	validators map[string]validators.ImageValidator
+}
+
+// NewValidator returns a digest Validator
+func NewValidator() Validator {
+	return &validator{
+		validators: validators.Create(),
+	}
+}
+
+func (v *validator) Validate(images []bundle.Image, allowMissingDigests bool) error {
+	for _, img := range images {
+		validator, ok := v.validators[img.ImageType]
+		if !ok {
+			return fmt.Errorf("unknown image type: %s", img.ImageType)
+		}
+		if img.Digest == "" && !allowMissingDigests {
+			return fmt.Errorf("unable to validate %s, digest not present", img.Image)
+		}
+		if img.Digest != "" {
+			if err := validator.Validate(img); err != nil {
+				return errors.Wrapf(err, "validation failed for %s", img.Image)
+			}
+		}
+	}
+	return nil
+}

--- a/digests/validation_test.go
+++ b/digests/validation_test.go
@@ -1,0 +1,147 @@
+package digests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/digests/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeImageValidator struct {
+	digest string
+}
+
+func (f fakeImageValidator) Validate(img bundle.Image) error {
+	if f.digest != img.Digest {
+		return fmt.Errorf("digest validation failed: expected %s found %s", img.Digest, f.digest)
+	}
+	return nil
+}
+
+func fakeValidator(fake fakeImageValidator) Validator {
+	return &validator{
+		validators: map[string]validators.ImageValidator{
+			validators.ImageTypeDocker: fake,
+		},
+	}
+}
+
+func emptyValidator() fakeImageValidator {
+	return fakeImageValidator{
+		digest: "",
+	}
+}
+
+func TestNoImages(t *testing.T) {
+	v := fakeValidator(emptyValidator())
+
+	imgs := []bundle.Image{}
+	err := v.Validate(imgs, true)
+	assert.NoError(t, err, "expected no error when no images were present")
+}
+
+func TestMissingDigestAllowed(t *testing.T) {
+	v := fakeValidator(emptyValidator())
+
+	imgs := []bundle.Image{
+		{
+			BaseImage: bundle.BaseImage{
+				Image:     "repo/someimage:v1.0.0",
+				ImageType: validators.ImageTypeDocker,
+				Digest:    "",
+			},
+		},
+	}
+
+	err := v.Validate(imgs, true)
+	assert.NoError(t, err, "expected no error for empty digest when allowMissingDigest is true")
+
+}
+
+func TestMissingDigestNotAllowed(t *testing.T) {
+	v := fakeValidator(emptyValidator())
+
+	imgs := []bundle.Image{
+		{
+			BaseImage: bundle.BaseImage{
+				Image:     "repo/someimage:v1.0.0",
+				ImageType: validators.ImageTypeDocker,
+				Digest:    "",
+			},
+		},
+	}
+	err := v.Validate(imgs, false)
+	assert.Error(t, err, "expected an error for empty digest when allowMissingDigest is false")
+	assert.EqualError(t, err, "unable to validate repo/someimage:v1.0.0, digest not present")
+}
+
+func TestDigestMatches(t *testing.T) {
+
+	v := fakeValidator(fakeImageValidator{
+		digest: "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5",
+	})
+
+	imgs := []bundle.Image{
+		{
+			BaseImage: bundle.BaseImage{
+				Image:     "repo/someimage:v1.0.0",
+				ImageType: validators.ImageTypeDocker,
+				Digest:    "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5",
+			},
+		},
+	}
+	err := v.Validate(imgs, false)
+	assert.NoError(t, err, "expected digests to match")
+}
+
+func TestDigestNotEqual(t *testing.T) {
+
+	actual := "sha256:cafebabe4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5"
+	expected := "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5"
+	imageName := "repo/someimage:v1.0.0"
+
+	v := fakeValidator(fakeImageValidator{
+		digest: actual,
+	})
+
+	imgs := []bundle.Image{
+		{
+			BaseImage: bundle.BaseImage{
+				Image:     imageName,
+				ImageType: validators.ImageTypeDocker,
+				Digest:    expected,
+			},
+		},
+	}
+	err := v.Validate(imgs, false)
+	assert.Error(t, err, "expected digests not to match")
+	assert.EqualError(
+		t,
+		err,
+		fmt.Sprintf(
+			"validation failed for %s: digest validation failed: expected %s found %s",
+			imageName,
+			expected,
+			actual,
+		),
+	)
+}
+
+func TestUnknownImageType(t *testing.T) {
+	v := fakeValidator(emptyValidator())
+
+	imgs := []bundle.Image{
+		{
+			BaseImage: bundle.BaseImage{
+				Image:     "repo/someimage:v1.0.0",
+				ImageType: "VirtualMachine",
+				Digest:    "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5",
+			},
+		},
+	}
+	err := v.Validate(imgs, false)
+	assert.Error(t, err, "expected VirtualMachine to be an invalid type")
+	assert.EqualError(t, err, "unknown image type: VirtualMachine")
+}

--- a/digests/validators/docker.go
+++ b/digests/validators/docker.go
@@ -1,0 +1,38 @@
+package validators
+
+import (
+	"fmt"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/registry"
+	"github.com/pkg/errors"
+)
+
+type dockerValidator struct {
+	registryClient registry.Client
+}
+
+// NewDockerValidator creates a new validator for Docker and OCI images
+func NewDockerValidator() ImageValidator {
+	return dockerValidator{
+		registryClient: registry.NewRegistryClient(),
+	}
+}
+
+// Validate creates a validator that obtains a digest from a repository
+// and compares that against the specified digest in the bundle.Image parameter
+func (d dockerValidator) Validate(img bundle.Image) error {
+	imgName, err := image.NewName(img.Image)
+	if err != nil {
+		return errors.Wrap(err, "unable to validate digest")
+	}
+	digest, err := d.registryClient.Digest(imgName)
+	if err != nil {
+		return errors.Wrap(err, "unable to obtain digest")
+	}
+	if digest.String() != img.Digest {
+		return fmt.Errorf("digest validation failed: expected %s found %s", digest.String(), img.Digest)
+	}
+	return nil
+}

--- a/digests/validators/docker_test.go
+++ b/digests/validators/docker_test.go
@@ -1,0 +1,77 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/registry"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeClient struct {
+	copyFake       func(source image.Name, target image.Name) (image.Digest, int64, error)
+	digestFake     func(img image.Name) (image.Digest, error)
+	layoutFake     func(path string) (registry.Layout, error)
+	readLayoutFake func(path string) (registry.Layout, error)
+}
+
+func (f fakeClient) Copy(source image.Name, target image.Name) (image.Digest, int64, error) {
+	return f.copyFake(source, target)
+}
+
+func (f fakeClient) Digest(img image.Name) (image.Digest, error) {
+	return f.digestFake(img)
+}
+
+func (f fakeClient) NewLayout(path string) (registry.Layout, error) {
+	return f.layoutFake(path)
+}
+
+func (f fakeClient) ReadLayout(path string) (registry.Layout, error) {
+	return f.readLayoutFake(path)
+}
+
+func TestDigestMatches(t *testing.T) {
+
+	client := fakeClient{
+		digestFake: func(img image.Name) (image.Digest, error) {
+			return image.NewDigest("sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5")
+		},
+	}
+
+	v := dockerValidator{
+		registryClient: client,
+	}
+
+	img := bundle.Image{
+		BaseImage: bundle.BaseImage{
+			Image:  "repo/someimage:v1.0.0",
+			Digest: "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5",
+		},
+	}
+	err := v.Validate(img)
+	assert.NoError(t, err, "expected digests to match")
+}
+
+func TestDigestNotEqual(t *testing.T) {
+
+	client := fakeClient{
+		digestFake: func(img image.Name) (image.Digest, error) {
+			return image.NewDigest("sha256:cafebabe4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5")
+		},
+	}
+
+	v := dockerValidator{
+		registryClient: client,
+	}
+
+	img := bundle.Image{
+		BaseImage: bundle.BaseImage{
+			Image:  "repo/someimage:v1.0.0",
+			Digest: "sha256:3eafa67f4db52455532b19b80bd6b9a7b99d12717b96dcf25ced4cb49fa6d2d5",
+		},
+	}
+	err := v.Validate(img)
+	assert.Error(t, err, "expected digests not to match")
+}

--- a/digests/validators/validator.go
+++ b/digests/validators/validator.go
@@ -1,0 +1,26 @@
+package validators
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+)
+
+// Known image types for validation
+const (
+	ImageTypeDocker = "docker"
+	ImageTypeOCI    = "oci"
+)
+
+// Create builds a new image validator collection for know image types
+func Create() map[string]ImageValidator {
+	d := NewDockerValidator()
+	return map[string]ImageValidator{
+		ImageTypeDocker: d,
+		ImageTypeOCI:    d,
+	}
+}
+
+// ImageValidator valdiates that the content digest for a given image matches
+// the source.
+type ImageValidator interface {
+	Validate(image bundle.Image) error
+}


### PR DESCRIPTION
This introduces a Validate interface for image contentDigest validation, along with an implementation for Docker and OCI images that uses github.com/pivotal/image-relocation to obtain the digest based on the specified image image (thanks for the suggestion @glyn). This also allows us to implement additional validators down the road.

By default, validation will fail if a digest is not provided in the Image struct. This can be overridden by setting allowMissingDigests to true.

Note: this doesn't actually change any of the drivers/operation code. Clients of cnab-go will need to invoke the validation before calling an operation. This is done in order to allow validation of ALL the images referenced in the bundle. Currently, `Operation` only knows about the invocation image. This also allows clients to handle things like relocation mapping or any other mapping of bundle image to actual image that might be run. It also didn't feel appropriate to place the validation calls in the driver's themselves, as a given operation might actually need to validate multiple image types down the road (example: we use a Docker based invocation image that deploys OVA files to some VMware infrastructure) and it seemed like a cleaner separation to not mix with the drivers. Also allows this to be called outside of the context of a call to a driver Run(..), but I'm happy to wire it up to the Operations if desired. 

Closes #101