### PR TITLE
fix(kubernetes): handle long installation names

### DIFF
--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -3,8 +3,10 @@ package kubernetes
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -31,6 +33,11 @@ const (
 	k8sContainerName    = "invocation"
 	k8sFileSecretVolume = "files"
 	numBackoffLoops     = 6
+	cnabPrefix          = "cnab.io/"
+)
+
+var (
+	dns1123Reg = regexp.MustCompile(`[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*`)
 )
 
 // Driver runs an invocation image in a Kubernetes cluster.
@@ -130,11 +137,14 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 	if k.Namespace == "" {
 		return driver.OperationResult{}, fmt.Errorf("KUBE_NAMESPACE is required")
 	}
-	labelMap := generateLabels(op)
+
 	meta := metav1.ObjectMeta{
 		Namespace:    k.Namespace,
 		GenerateName: generateNameTemplate(op),
-		Labels:       labelMap,
+		Labels: map[string]string{
+			"cnab.io/driver": "kubernetes",
+		},
+		Annotations: generateMergedAnnotations(op, k.Annotations),
 	}
 	// Mount SA token if a non-zero value for ServiceAccountName has been specified
 	mountServiceAccountToken := k.ServiceAccountName != ""
@@ -146,8 +156,8 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 			BackoffLimit:          &k.BackoffLimit,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labelMap,
-					Annotations: k.Annotations,
+					Labels:      meta.Labels,
+					Annotations: meta.Annotations,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName:           k.ServiceAccountName,
@@ -177,19 +187,19 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 			StringData: op.Environment,
 		}
 		secret.ObjectMeta.GenerateName += "env-"
-		envsecret, err := k.secrets.Create(secret)
+		secret, err := k.secrets.Create(secret)
 		if err != nil {
 			return driver.OperationResult{}, err
 		}
 		if !k.SkipCleanup {
-			defer k.deleteSecret(envsecret.ObjectMeta.Name)
+			defer k.deleteSecret(secret.ObjectMeta.Name)
 		}
 
 		container.EnvFrom = []v1.EnvFromSource{
 			{
 				SecretRef: &v1.SecretEnvSource{
 					LocalObjectReference: v1.LocalObjectReference{
-						Name: envsecret.ObjectMeta.Name,
+						Name: secret.ObjectMeta.Name,
 					},
 				},
 			},
@@ -198,11 +208,8 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 
 	if len(op.Files) > 0 {
 		secret, mounts := generateFileSecret(op.Files)
-		secret.ObjectMeta = metav1.ObjectMeta{
-			Namespace:    k.Namespace,
-			GenerateName: generateNameTemplate(op) + "files-",
-			Labels:       labelMap,
-		}
+		secret.ObjectMeta = meta
+		secret.ObjectMeta.GenerateName += "files-"
 		secret, err := k.secrets.Create(secret)
 		if err != nil {
 			return driver.OperationResult{}, err
@@ -363,15 +370,37 @@ func (k *Driver) deleteJob(name string) error {
 }
 
 func generateNameTemplate(op *driver.Operation) string {
-	return fmt.Sprintf("%s-%s-", op.Installation, op.Action)
+	name := fmt.Sprintf("%s-%s", op.Action, op.Installation)
+	if len(name) > 50 {
+		name = name[0:39]
+	}
+
+	var result string
+	for _, match := range dns1123Reg.FindAllString(strings.ToLower(name), 10) {
+		result += match
+	}
+
+	return result + "-"
 }
 
-func generateLabels(op *driver.Operation) map[string]string {
-	return map[string]string{
+func generateMergedAnnotations(op *driver.Operation, mergeWith map[string]string) map[string]string {
+	anno := map[string]string{
 		"cnab.io/installation": op.Installation,
 		"cnab.io/action":       op.Action,
 		"cnab.io/revision":     op.Revision,
 	}
+
+	if mergeWith != nil {
+		for k, v := range mergeWith {
+			if strings.HasPrefix(k, cnabPrefix) {
+				log.Printf("Annotations with prefix '%s' are reserved. Annotation '%s: %s' will not be applied.\n", cnabPrefix, k, v)
+				continue
+			}
+			anno[k] = v
+		}
+	}
+
+	return anno
 }
 
 func generateFileSecret(files map[string]string) (*v1.Secret, []v1.VolumeMount) {

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -43,6 +43,24 @@ func TestDriver_Run_Integration(t *testing.T) {
 			output: "Port parameter was set to 3000\nInstall action\nAction install complete for example\n",
 			err:    nil,
 		},
+		{
+			name: "long installation name",
+			op: &driver.Operation{
+				Installation: "greater-than-300-length-and-special-chars/-*()+%@qcUYSfR9MS3BqR0kRDHe2K5EHJa8BJGrcoiDVvsDpATjIkrk4PWrdysIqFpJzrKHauRWfBjjF889Qdc5DUBQ6gKy8Qezkl9HyCmo88hMrkaeVPxknFt0nWRm0xqYhoaY0Db7ZcljchbBAufVvH5l0T7iBdg1E0iSCTZw0v5rCAEclNwzjpg7DfLq2SBdJ0W8XdyQSWVMpakjraXP9droq8ol70gX0QuqAZDkGtHyxet8Akv9lGCCVVFuY4kBdkW3LDHoxl0xz2EZzXja1GTlYui0Bpx0TGqMLish9tBOhuC7",
+				Action:       "install",
+				Image: bundle.InvocationImage{
+					BaseImage: bundle.BaseImage{
+						Image:  "cnab/helloworld",
+						Digest: "sha256:55f83710272990efab4e076f9281453e136980becfd879640b06552ead751284",
+					},
+				},
+				Environment: map[string]string{
+					"PORT": "3000",
+				},
+			},
+			output: "Port parameter was set to 3000\nInstall action\nAction install complete for greater-than-300-length-and-special-chars/-*()+%@qcUYSfR9MS3BqR0kRDHe2K5EHJa8BJGrcoiDVvsDpATjIkrk4PWrdysIqFpJzrKHauRWfBjjF889Qdc5DUBQ6gKy8Qezkl9HyCmo88hMrkaeVPxknFt0nWRm0xqYhoaY0Db7ZcljchbBAufVvH5l0T7iBdg1E0iSCTZw0v5rCAEclNwzjpg7DfLq2SBdJ0W8XdyQSWVMpakjraXP9droq8ol70gX0QuqAZDkGtHyxet8Akv9lGCCVVFuY4kBdkW3LDHoxl0xz2EZzXja1GTlYui0Bpx0TGqMLish9tBOhuC7\n",
+			err:    nil,
+		},
 	}
 
 	for _, tc := range cases {

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -77,3 +77,47 @@ func TestImageWithDigest(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateNameTemplate(t *testing.T) {
+	testCases := map[string]struct {
+		op       *driver.Operation
+		expected string
+	}{
+		"short name": {
+			op: &driver.Operation{
+				Action:       "install",
+				Installation: "foo",
+			},
+			expected: "install-foo-",
+		},
+		"special chars": {
+			op: &driver.Operation{
+				Action:       "example.com/liftoff",
+				Installation: "🚀 me to the 🌙",
+			},
+			expected: "example.com-liftoff-me-to-the-",
+		},
+		"long installation name": {
+			op: &driver.Operation{
+				Action:       "install",
+				Installation: "this-should-be-truncated-qcUYSfR9MS3BqR0kRDHe2K5EHJa8BJGrcoiDVvsDpATjIkr",
+			},
+			expected: "install-this-should-be-truncated-qcuysfr9ms3bqr0k-",
+		},
+		"maximum matching segments": {
+			op: &driver.Operation{
+				Action:       "a",
+				Installation: "b c d e f g h i j k l m n o p q r s t u v w x y z",
+			},
+			expected: "a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := generateNameTemplate(tc.op)
+			assert.Equal(t, tc.expected, actual)
+			assert.True(t, len(actual) <= maxNameTemplateLength)
+		})
+	}
+}


### PR DESCRIPTION
Long installation or action names currently cause the Kubernetes driver to fail because of character limits imposed by the platform ([63 chars for label values](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) and [253 chars for resource names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)).

This PR ensures that only valid DNS-1123 resource names less than the maximum length are generated, and uses annotations instead of labels for storing metadata about which jobs are associated with which operations.