### PR TITLE
Fix Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,26 @@
 We have [good first issues][good-first-issue] for new contributors and [help wanted][help-wanted] issues for our other contributors.
 
-* `good first issue` has extra information to help you make your first contribution.
-* `help wanted` are issues suitable for someone who isn't a core maintainer.
+- `good first issue` has extra information to help you make your first contribution.
+- `help wanted` are issues suitable for someone who isn't a core maintainer.
 
 Maintainers will do our best regularly make new issues for you to solve and then help out as you work on them. 💖
 
 # Philosophy
+
 PRs are most welcome!
 
-* If there isn't an issue for your PR, please make an issue first and explain the problem or motivation for
-the change you are proposing. When the solution isn't straightforward, for example "Implement missing command X",
-then also outline your proposed solution. Your PR will go smoother if the solution is agreed upon before you've
-spent a lot of time implementing it.
-  * It's OK to submit a PR directly for problems such as misspellings or other things where the motivation/problem is
+- If there isn't an issue for your PR, please make an issue first and explain the problem or motivation for
+  the change you are proposing. When the solution isn't straightforward, for example "Implement missing command X",
+  then also outline your proposed solution. Your PR will go smoother if the solution is agreed upon before you've
+  spent a lot of time implementing it.
+  - It's OK to submit a PR directly for problems such as misspellings or other things where the motivation/problem is
     unambiguous.
-* If you aren't sure about your solution yet, put WIP in the title or open as a draft PR so that people know to be nice and 
-wait for you to finish before commenting.
-* Try to keep your PRs to a single task. Please don't tackle multiple things in a single PR if possible. Otherwise, grouping related changes into commits will help us out a bunch when reviewing!
-* We encourage "follow-on PRs". If the core of your changes are good, and it won't hurt to do more of
-the changes later, we like to merge early, and keep working on it in another PR so that others can build
-on top of your work.
+- If you aren't sure about your solution yet, put WIP in the title or open as a draft PR so that people know to be nice and
+  wait for you to finish before commenting.
+- Try to keep your PRs to a single task. Please don't tackle multiple things in a single PR if possible. Otherwise, grouping related changes into commits will help us out a bunch when reviewing!
+- We encourage "follow-on PRs". If the core of your changes are good, and it won't hurt to do more of
+  the changes later, we like to merge early, and keep working on it in another PR so that others can build
+  on top of your work.
 
 When you're ready to get started, we recommend the following workflow:
 
@@ -31,52 +32,54 @@ $ golangci-lint run --config ./golangci.yml
 
 We currently use [dep](https://github.com/golang/dep) for dependency management.
 
-[good-first-issue]: https://github.com/deislabs/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
-[help-wanted]: https://github.com/deislabs/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+[good-first-issue]: https://github.com/cnabio/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[help-wanted]: https://github.com/cnabio/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 
 # Cutting a Release
 
 When you are asked to cut a new release, here is the process:
 
 1. Figure out the correct version number, we follow [semver](semver.org) and
-    have a funny [release naming scheme][release-name]:
-    * Bump the major segment if there are any breaking changes.
-    * Bump the minor segment if there are new features only.
-    * Bump the patch segment if there are bug fixes only.
-    * Bump the build segment (version-prerelease.BUILDTAG+releasename) if you only
-      fixed something in the build, but the final binaries are the same.
+   have a funny [release naming scheme][release-name]:
+   - Bump the major segment if there are any breaking changes.
+   - Bump the minor segment if there are new features only.
+   - Bump the patch segment if there are bug fixes only.
+   - Bump the build segment (version-prerelease.BUILDTAG+releasename) if you only
+     fixed something in the build, but the final binaries are the same.
 1. Figure out if the release name (version-prerelease.buildtag+RELEASENAME) should
-    change.
-    
-    * Keep the release name the same if it is just a build tag or patch bump.
-    * It is a new release name for major and minor bumps.
-    
-    If you need a new release name, it must be conversation with the team.
-    [Release naming scheme][release-name] explains the meaning behind the
-    release names.
+   change.
+
+   - Keep the release name the same if it is just a build tag or patch bump.
+   - It is a new release name for major and minor bumps.
+
+   If you need a new release name, it must be conversation with the team.
+   [Release naming scheme][release-name] explains the meaning behind the
+   release names.
+
 1. Ensure that the master CI build is passing, then make the tag and push it.
 
-    ```
-    git checkout master
-    git pull
-    git tag VERSION -a -m ""
-    git push --tags
-    ```
+   ```
+   git checkout master
+   git pull
+   git tag VERSION -a -m ""
+   git push --tags
+   ```
 
 1. Generate some release notes and put them into the release on GitHub.
-    The following command gives you a list of all the merged pull requests:
+   The following command gives you a list of all the merged pull requests:
 
-    ```
-    git log --oneline OLDVERSION..NEWVERSION  | grep "#" > gitlog.txt
-    ```
+   ```
+   git log --oneline OLDVERSION..NEWVERSION  | grep "#" > gitlog.txt
+   ```
 
-    You need to go through that and make a bulleted list of features
-    and fixes with the PR titles and links to the PR. If you come up with an
-    easier way of doing this, please submit a PR to update these instructions. 😅
+   You need to go through that and make a bulleted list of features
+   and fixes with the PR titles and links to the PR. If you come up with an
+   easier way of doing this, please submit a PR to update these instructions. 😅
 
-    ```
-    # Features
-    * PR TITLE (#PR NUMBER)
+   ```
+   # Features
+   * PR TITLE (#PR NUMBER)
 
-    # Fixes
-    * PR TITLE (#PR NUMBER)
+   # Fixes
+   * PR TITLE (#PR NUMBER)
+   ```

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,14 +1,16 @@
 # Governance
 
 ## Project Maintainers
+
 [Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating CNAB-go, a library for the [CNAB spec](https://github.com/deislabs/cnab-spec). Final decisions on the project reside with the project maintainers.
 
 Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
 
 New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
 
-A maintainer may step down by submitting an [issue](https://github.com/deislabs/cnab-go/issues/new) stating their intent.
+A maintainer may step down by submitting an [issue](https://github.com/cnabio/cnab-go/issues/new) stating their intent.
 
 ## Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -8,24 +8,25 @@ cnab-go is currently being used by [Docker App](https://github.com/docker/app), 
 
 ### Community
 
-cnab-go is [maintained](GOVERNANCE.md) by the CNAB community. We sometimes discuss cnab-go issues during the [bi-weekly CNAB community  meeting](https://hackmd.io/s/SyGcBcwQ4), but we encourage open communication via our [issue](https://github.com/deislabs/cnab-go/issues) queue and via [PRs](https://github.com/deislabs/cnab-go/pulls). If you are interested in contributing to cnab-go, please refer to our [contributing](CONTRIBUTING.md) guidelines.
+cnab-go is [maintained](GOVERNANCE.md) by the CNAB community. We sometimes discuss cnab-go issues during the [bi-weekly CNAB community meeting](https://hackmd.io/s/SyGcBcwQ4), but we encourage open communication via our [issue](https://github.com/cnabio/cnab-go/issues) queue and via [PRs](https://github.com/cnabio/cnab-go/pulls). If you are interested in contributing to cnab-go, please refer to our [contributing](CONTRIBUTING.md) guidelines.
 
 ### Development
 
 #### Getting the code
 
 Cloning this repository and change directory to it:
+
 ```bash
-$ go get -d github.com/deislabs/cnab-go/...
-$ cd $(go env GOPATH)/src/github.com/deislabs/cnab-go
+$ go get -d github.com/cnabio/cnab-go/...
+$ cd $(go env GOPATH)/src/github.com/cnabio/cnab-go
 ```
 
 #### Prerequisites
 
 You need:
 
-* make
-* Go
+- make
+- Go
 
 #### Get dependencies
 
@@ -60,7 +61,7 @@ $ make integration-test
 ```
 
 This will only run the linter to ensure the code meet the standard.
-*It does not format the code*
+_It does not format the code_
 
 ```bash
 $ make lint

--- a/action/action.go
+++ b/action/action.go
@@ -7,11 +7,11 @@ import (
 	"math"
 	"strings"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/definition"
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // stateful is there just to make callers of opFromClaims more readable

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/action/install.go
+++ b/action/install.go
@@ -1,9 +1,9 @@
 package action
 
 import (
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Install describes an installation action

--- a/action/install_test.go
+++ b/action/install_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/action/operation_configs.go
+++ b/action/operation_configs.go
@@ -1,7 +1,7 @@
 package action
 
 import (
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // OperationConfigFunc is a configuration function that can be applied to an

--- a/action/operation_configs_test.go
+++ b/action/operation_configs_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/action/run_custom.go
+++ b/action/run_custom.go
@@ -3,9 +3,9 @@ package action
 import (
 	"errors"
 
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 var (

--- a/action/run_custom_test.go
+++ b/action/run_custom_test.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/action/status.go
+++ b/action/status.go
@@ -1,9 +1,9 @@
 package action
 
 import (
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Status runs a status action on a CNAB bundle.

--- a/action/status_test.go
+++ b/action/status_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/action/uninstall.go
+++ b/action/uninstall.go
@@ -1,9 +1,9 @@
 package action
 
 import (
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Uninstall runs an uninstall action

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/action/upgrade.go
+++ b/action/upgrade.go
@@ -1,9 +1,9 @@
 package action
 
 import (
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/credentials"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/credentials"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Upgrade runs an upgrade action

--- a/action/upgrade_test.go
+++ b/action/upgrade_test.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/claim"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  GOROOT: '/usr/local/go1.11' # Go installation path
+  GOROOT: '/usr/local/go1.13' # Go installation path
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
 
@@ -20,7 +20,6 @@ steps:
 
 - script: |
     go version
-    go get -v -t -d ./...
     make bootstrap build test lint coverage
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, build, test'

--- a/brigade.js
+++ b/brigade.js
@@ -3,7 +3,7 @@ const { events, Job } = require("brigadier");
 const projectOrg = "cnabio";
 const projectName = "cnab-go";
 
-const goImg = "golang:1.11";
+const goImg = "golang:1.13";
 const gopath = "/go";
 const localPath = gopath + `/src/github.com/${projectOrg}/${projectName}`;
 

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/deislabs/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/docker/go/canonical/json"
 	pkgErrors "github.com/pkg/errors"
 )

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/bundle/loader/loader.go
+++ b/bundle/loader/loader.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 // BundleLoader provides an interface for loading a bundle

--- a/claim/claim.go
+++ b/claim/claim.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/oklog/ulid"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 // Status constants define the CNAB status fields on a Result.

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/qri-io/jsonschema"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 func TestNew(t *testing.T) {

--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/deislabs/cnab-go/utils/crud"
+	"github.com/cnabio/cnab-go/utils/crud"
 )
 
 // ErrClaimNotFound represents a claim not found in claim storage

--- a/claim/claimstore_test.go
+++ b/claim/claimstore_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/utils/crud"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/utils/crud"
 )
 
 func TestCanSaveReadAndDelete(t *testing.T) {

--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 
 	yaml "gopkg.in/yaml.v2"
 )

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -2,7 +2,7 @@ name: staging
 credentials:
   - name: read_file
     source:
-      path: $GOPATH/src/github.com/deislabs/cnab-go/credentials/testdata/someconfig.txt
+      path: $GOPATH/src/github.com/cnabio/cnab-go/credentials/testdata/someconfig.txt
   - name: run_program
     source:
       command: "echo wildebeest"
@@ -13,7 +13,7 @@ credentials:
   - name: fallthrough
     source:
       name: NO_SUCH_VAR
-      value: quokka 
+      value: quokka
   - name: plain_value
     source:
       value: cassowary

--- a/credentials/testdata/staging-windows.yaml
+++ b/credentials/testdata/staging-windows.yaml
@@ -2,7 +2,7 @@ name: staging
 credentials:
   - name: read_file
     source:
-      path: $GOPATH/src/github.com/deislabs/cnab-go/credentials/testdata/someconfig.txt
+      path: $GOPATH/src/github.com/cnabio/cnab-go/credentials/testdata/someconfig.txt
   - name: run_program
     source:
       command: "cmd.exe /c echo wildebeest"

--- a/driver/command/command.go
+++ b/driver/command/command.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Driver relies upon a system command to provide a driver implementation

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/definition"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/driver/command/command_test.go
+++ b/driver/command/command_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 var _ driver.Driver = &Driver{}

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	unix_path "path"
 
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/docker/cli/cli/command"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/distribution/reference"

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/definition"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/docker/go/canonical/json"
 )
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 const (

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -6,8 +6,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/driver"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/driver/lookup/lookup.go
+++ b/driver/lookup/lookup.go
@@ -3,10 +3,10 @@ package lookup
 import (
 	"fmt"
 
-	"github.com/deislabs/cnab-go/driver"
-	"github.com/deislabs/cnab-go/driver/command"
-	"github.com/deislabs/cnab-go/driver/docker"
-	"github.com/deislabs/cnab-go/driver/kubernetes"
+	"github.com/cnabio/cnab-go/driver"
+	"github.com/cnabio/cnab-go/driver/command"
+	"github.com/cnabio/cnab-go/driver/docker"
+	"github.com/cnabio/cnab-go/driver/kubernetes"
 )
 
 // Lookup takes a driver name and tries to resolve the most pertinent driver.

--- a/imagestore/construction/construction.go
+++ b/imagestore/construction/construction.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/deislabs/cnab-go/imagestore"
-	"github.com/deislabs/cnab-go/imagestore/ocilayout"
-	"github.com/deislabs/cnab-go/imagestore/remote"
+	"github.com/cnabio/cnab-go/imagestore"
+	"github.com/cnabio/cnab-go/imagestore/ocilayout"
+	"github.com/cnabio/cnab-go/imagestore/remote"
 )
 
 // NewConstructor creates an image store constructor which will, if necessary, create archive contents.

--- a/imagestore/ocilayout/ocilayout.go
+++ b/imagestore/ocilayout/ocilayout.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pivotal/image-relocation/pkg/registry"
 	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 
-	"github.com/deislabs/cnab-go/imagestore"
+	"github.com/cnabio/cnab-go/imagestore"
 )
 
 // ociLayout is an image store which stores images as an OCI image layout.

--- a/imagestore/remote/remote.go
+++ b/imagestore/remote/remote.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pivotal/image-relocation/pkg/registry"
 	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 
-	"github.com/deislabs/cnab-go/imagestore"
+	"github.com/cnabio/cnab-go/imagestore"
 )
 
 // remote is an image store which does not actually store images. It is used to represent thin bundles.

--- a/packager/export.go
+++ b/packager/export.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/loader"
-	"github.com/deislabs/cnab-go/imagestore"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/loader"
+	"github.com/cnabio/cnab-go/imagestore"
 	"github.com/docker/docker/pkg/archive"
 )
 

--- a/packager/export_test.go
+++ b/packager/export_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle/loader"
-	"github.com/deislabs/cnab-go/imagestore"
-	"github.com/deislabs/cnab-go/imagestore/imagestoremocks"
+	"github.com/cnabio/cnab-go/bundle/loader"
+	"github.com/cnabio/cnab-go/imagestore"
+	"github.com/cnabio/cnab-go/imagestore/imagestoremocks"
 )
 
 func TestExport(t *testing.T) {

--- a/packager/import.go
+++ b/packager/import.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/deislabs/cnab-go/bundle"
-	"github.com/deislabs/cnab-go/bundle/loader"
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/bundle/loader"
 	"github.com/docker/docker/pkg/archive"
 )
 
@@ -35,7 +35,7 @@ func NewImporter(source, destination string, load loader.BundleLoader) *Importer
 func (im *Importer) Import() error {
 	_, _, err := im.Unzip()
 
-	// TODO: https://github.com/deislabs/cnab-go/issues/136
+	// TODO: https://github.com/cnabio/cnab-go/issues/136
 
 	return err
 }

--- a/packager/import_test.go
+++ b/packager/import_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deislabs/cnab-go/bundle/loader"
+	"github.com/cnabio/cnab-go/bundle/loader"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
CI was failing because of the github org change messing up gopath imports.

We should probably switch to go modules, but in the mean time these import changes will need to be made either way.

Existing developer's checkouts will need to be moved from `$GOPATH/src/github.com/deislabs/cnab-go` to `$GOPATH/src/github.com/cnabio/cnab-go`.