### PR TITLE
fix(brigade.js): temp disable appending job logs to GH notification

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -206,20 +206,29 @@ class Notification {
 }
 
 // Helper to wrap a job execution between two notifications.
-async function notificationWrap(job, note) {
+async function notificationWrap(job, note, conclusion) {
+  if (conclusion == null) {
+    conclusion = "success"
+  }
   await note.run();
   try {
     let res = await job.run();
     const logs = await job.logs();
-    note.conclusion = "success";
+    note.conclusion = conclusion;
     note.summary = `Task "${ job.name }" passed`;
-    note.text = "```" + res.toString() + "```\nTest Complete";
+    // TODO: re-enable appending response/logs once Brigade issue fixed
+    // https://github.com/brigadecore/brigade-github-app/issues/36
+    //
+    // note.text = "```" + res.toString() + "```\nTest Complete";
+    note.text = `Task Complete: ${conclusion}`;
     return await note.run();
   } catch (e) {
     const logs = await job.logs();
     note.conclusion = "failure";
     note.summary = `Task "${ job.name }" failed for ${ e.buildID }`;
-    note.text = "```" + logs + "```\nFailed with error: " + e.toString();
+    // See TODO above
+    // note.text = "```" + logs + "```\nFailed with error: " + e.toString();
+    note.text = "Task failed with error: " + e.toString();
     try {
       await note.run();
     } catch (e2) {


### PR DESCRIPTION
The notifications sent by Brigade to GitHub around CI/check runs are failing due to https://github.com/brigadecore/brigade-github-app/issues/36

This PR disables appending the job logs to the notifications until 36 is resolved.