### PR TITLE
fix(*): bump golangci-lint; fix linting err

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	golangci-lint run --config ./golangci.yml
 
 HAS_GOLANGCI     := $(shell $(CHECK) golangci-lint)
-GOLANGCI_VERSION := v1.16.0
+GOLANGCI_VERSION := v1.21.0
 
 HAS_GOCOV_XML := $(shell command -v gocov-xml;)
 HAS_GOCOV := $(shell command -v gocov;)

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -397,14 +397,12 @@ func generateMergedAnnotations(op *driver.Operation, mergeWith map[string]string
 		"cnab.io/revision":     op.Revision,
 	}
 
-	if mergeWith != nil {
-		for k, v := range mergeWith {
-			if strings.HasPrefix(k, cnabPrefix) {
-				log.Printf("Annotations with prefix '%s' are reserved. Annotation '%s: %s' will not be applied.\n", cnabPrefix, k, v)
-				continue
-			}
-			anno[k] = v
+	for k, v := range mergeWith {
+		if strings.HasPrefix(k, cnabPrefix) {
+			log.Printf("Annotations with prefix '%s' are reserved. Annotation '%s: %s' will not be applied.\n", cnabPrefix, k, v)
+			continue
 		}
+		anno[k] = v
 	}
 
 	return anno


### PR DESCRIPTION
* bumps golangci-lint version to latest
  - this was motivated by seeing quite lengthy output in CI using the previous/outdated version, e.g. https://brigadecore.github.io/kashti/jobs/tests-01dvcyr1x6pk73cm2fh2v6h9xz.  It appears the bump eliminates this issue; see the test run here: https://brigadecore.github.io/kashti/jobs/tests-01dvedzvxfvn6beeb8k1r8a245

* addresses the following linting error seen locally:

```
 $ make lint
golangci-lint run --config ./golangci.yml
driver/kubernetes/kubernetes.go:400:2: S1031: unnecessary nil check around range (gosimple)
	if mergeWith != nil {
	^
make: *** [lint] Error 1
```