### PR TITLE
Execute integration tests in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ vendor/
 __pycache__/
 /duffle
 .vscode/settings.json
+
+# Test Output
+kind-kubeconfig.yaml
+coverage.*
+report.xml
+go_test.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cnab-go
 
-[![Build Status](https://dev.azure.com/deislabs/cnab-go/_apis/build/status/cnab-go?branchName=master)](https://dev.azure.com/deislabs/cnab-go/_build/latest?definitionId=14&branchName=master) ![Azure Pipelines coverage](https://img.shields.io/azure-devops/coverage/deislabs/cnab-go/14?logo=Azure%20Pipelines&style=flat)
+[![Build Status](https://dev.azure.com/deislabs/cnab-go/_apis/build/status/cnab-go?branchName=master)](https://dev.azure.com/deislabs/cnab-go/_build/latest?definitionId=27&branchName=master) ![Azure Pipelines coverage](https://img.shields.io/azure-devops/coverage/deislabs/cnab-go/27/master?logo=Azure%20Pipelines)
 
 cnab-go is a library for building [CNAB](https://github.com/deislabs/cnab-spec) clients. It provides the building blocks relevant to the CNAB specification so that you may build tooling without needing to implement all aspects of the CNAB specification.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,10 @@ steps:
     testRunner: JUnit
     testResultsFiles: $(System.DefaultWorkingDirectory)/**/report.xml
     failTaskOnFailedTests: true
+  condition: always()
 
 - task: PublishCodeCoverageResults@1
   inputs:
     codeCoverageTool: Cobertura 
     summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml
+  condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,8 @@ steps:
 
 - script: |
     go version
-    make bootstrap build test lint coverage
+    go get sigs.k8s.io/kind@v0.6.0
+    make bootstrap build lint coverage
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, build, test'
 
@@ -28,6 +29,7 @@ steps:
   inputs:
     testRunner: JUnit
     testResultsFiles: $(System.DefaultWorkingDirectory)/**/report.xml
+    failTaskOnFailedTests: true
 
 - task: PublishCodeCoverageResults@1
   inputs:

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -2,7 +2,7 @@ name: staging
 credentials:
   - name: read_file
     source:
-      path: $GOPATH/src/github.com/cnabio/cnab-go/credentials/testdata/someconfig.txt
+      path: testdata/someconfig.txt
   - name: run_program
     source:
       command: "echo wildebeest"

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -4,6 +4,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -12,10 +13,10 @@ import (
 )
 
 func TestDriver_Run_Integration(t *testing.T) {
-	namespace := "default"
 	k := &Driver{}
 	k.SetConfig(map[string]string{
-		"KUBE_NAMESPACE": namespace,
+		"KUBE_NAMESPACE": "default",
+		"KUBECONFIG":     os.Getenv("KUBECONFIG"),
 	})
 	k.ActiveDeadlineSeconds = 60
 

--- a/e2e-kind.sh
+++ b/e2e-kind.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Adapted from https://github.com/helm/chart-testing/blob/b8572749f073372c64323618ca13255677376e0d/e2e-kind.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME=cnab-go-testing
+readonly CLUSTER_NAME
+
+K8S_VERSION=v1.15.3
+readonly K8S_VERSION
+
+KIND_KUBECONFIG="$PWD/kind-kubeconfig.yaml"
+readonly KIND_KUBECONFIG
+
+GO_TEST_COMMAND="go test -tags=integration -v -coverprofile=coverage.txt -covermode count ./..."
+readonly GO_TEST_COMMAND
+
+GO_TEST_LOG="go_test.log"
+readonly GO_TEST_LOG
+
+create_kind_cluster() {
+    kind create cluster \
+      --name "$CLUSTER_NAME" \
+      --image "kindest/node:$K8S_VERSION" \
+      --kubeconfig "$KIND_KUBECONFIG" \
+      --wait 300s
+
+    kubectl cluster-info --kubeconfig $KIND_KUBECONFIG
+    echo
+
+    kubectl get nodes --kubeconfig $KIND_KUBECONFIG
+    echo
+
+    echo 'Cluster ready!'
+    echo
+}
+
+test_e2e() {
+    echo "Running $GO_TEST_COMMAND"
+
+    KUBECONFIG="$KIND_KUBECONFIG" $GO_TEST_COMMAND >"$GO_TEST_LOG" 2>&1
+    echo
+}
+
+print_versions() {
+    echo "kind version: $(kind version)"
+    echo "kubectl version: $(kubectl version)"
+}
+
+cleanup() {
+    cat "$GO_TEST_LOG"
+    echo
+
+    cat "$GO_TEST_LOG" | go-junit-report > report.xml
+    gocov convert coverage.txt > coverage.json
+    gocov-xml < coverage.json > coverage.xml
+
+    kind delete cluster --name "$CLUSTER_NAME"
+    echo 'Done!'
+}
+
+main() {
+    trap cleanup EXIT
+
+    print_versions
+    create_kind_cluster
+    test_e2e
+}
+
+main

--- a/e2e-kind.sh
+++ b/e2e-kind.sh
@@ -15,7 +15,7 @@ readonly K8S_VERSION
 KIND_KUBECONFIG="$PWD/kind-kubeconfig.yaml"
 readonly KIND_KUBECONFIG
 
-GO_TEST_COMMAND="go test -tags=integration -v -coverprofile=coverage.txt -covermode count ./..."
+GO_TEST_COMMAND="go test -tags=integration -v -coverprofile=coverage.txt -covermode atomic ./..."
 readonly GO_TEST_COMMAND
 
 GO_TEST_LOG="go_test.log"


### PR DESCRIPTION
This PR
- Runs docker and kubernetes driver integration tests (using [kind](https://github.com/kubernetes-sigs/kind) for kubernetes environment setup)
- Configures the azure pipeline to always report test results and coverage, even on failure
- Increases test code coverage in CI for the `driver/docker` package from 0% to 62%, and for `driver/kubernetes` from 21% to 68%.

See new coverage reporting here: https://dev.azure.com/deislabs/cnab-go/_build/results?buildId=4231&view=codecoverage-tab