### PR TITLE
Reference images by digest in docker driver

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -96,6 +96,15 @@ func (i *BaseImage) DeepCopy() *BaseImage {
 	return &i2
 }
 
+// DigestedRef returns an image reference which can be used to pull by digest using Docker or Kubernetes.
+// If no digest is available, only the image will be returned and the boolean value will be false.
+func (i *BaseImage) DigestedRef() (string, bool) {
+	if i.Digest == "" {
+		return i.Image, false
+	}
+	return fmt.Sprintf("%s@%s", i.Image, i.Digest), true
+}
+
 // Image describes a container image in the bundle
 type Image struct {
 	BaseImage   `yaml:",inline"`

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/driver"
 )
 
@@ -166,9 +165,10 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 			},
 		},
 	}
+	digestedRef, _ := op.Image.DigestedRef()
 	container := v1.Container{
 		Name:    k8sContainerName,
-		Image:   imageWithDigest(op.Image),
+		Image:   digestedRef,
 		Command: []string{"/cnab/app/run"},
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
@@ -443,11 +443,4 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
-}
-
-func imageWithDigest(img bundle.InvocationImage) string {
-	if img.Digest == "" {
-		return img.Image
-	}
-	return img.Image + "@" + img.Digest
 }

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,44 +37,6 @@ func TestDriver_Run(t *testing.T) {
 
 	secretList, _ := k.secrets.List(metav1.ListOptions{})
 	assert.Equal(t, len(secretList.Items), 1, "expected one secret to be created")
-}
-
-func TestImageWithDigest(t *testing.T) {
-	testCases := map[string]bundle.InvocationImage{
-		"foo": {
-			BaseImage: bundle.BaseImage{
-				Image: "foo",
-			},
-		},
-		"foo/bar": {
-			BaseImage: bundle.BaseImage{
-				Image: "foo/bar",
-			},
-		},
-		"foo/bar:baz": {
-			BaseImage: bundle.BaseImage{
-				Image: "foo/bar:baz",
-			},
-		},
-		"foo/bar:baz@sha:a1b2c3": {
-			BaseImage: bundle.BaseImage{
-				Image:  "foo/bar:baz",
-				Digest: "sha:a1b2c3",
-			},
-		},
-		"foo/bar@sha:a1b2c3": {
-			BaseImage: bundle.BaseImage{
-				Image:  "foo/bar",
-				Digest: "sha:a1b2c3",
-			},
-		},
-	}
-
-	for expectedImageRef, img := range testCases {
-		t.Run(expectedImageRef, func(t *testing.T) {
-			assert.Equal(t, expectedImageRef, imageWithDigest(img))
-		})
-	}
 }
 
 func TestGenerateNameTemplate(t *testing.T) {


### PR DESCRIPTION
This builds on the work in https://github.com/cnabio/cnab-go/pull/114 by supporting the same functionality for the docker driver.