### PR TITLE
Waiting container to stop after started container, not before

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -231,10 +231,10 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		}
 	}()
 
-	statusc, errc := cli.Client().ContainerWait(ctx, resp.ID, container.WaitConditionNextExit)
 	if err = cli.Client().ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
 		return driver.OperationResult{}, fmt.Errorf("cannot start container: %v", err)
 	}
+	statusc, errc := cli.Client().ContainerWait(ctx, resp.ID, container.WaitConditionNextExit)
 	select {
 	case err := <-errc:
 		if err != nil {


### PR DESCRIPTION
Waiting container to stop is not working in old Docker API version(1.24).

In old Docker API version(1.24), before docker container started, `docker wait` will return immediately. In this case, `ContainerWait` function which creates a goroutine to wait container to stop, may send a message to  `statusc ` before container started, and this will make waiting container to stop fail.

Trying to wait container to stop after started container, and this will make waiting container work well.

Related source code:
[https://github.com/moby/moby/blob/1.12.x/container/state.go#L129](url) 