### PR TITLE
Add timestamps to CredentialSet

### DIFF
--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/cnabio/cnab-go/bundle"
-
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -59,7 +59,11 @@ func (s Set) Merge(s2 Set) error {
 type CredentialSet struct {
 	// Name is the name of the credentialset.
 	Name string `json:"name" yaml:"name"`
-	// Creadentials is a list of credential specs.
+	// Created timestamp of the credentialset.
+	Created time.Time `json:"created" yaml:"created"`
+	// Modified timestamp of the credentialset.
+	Modified time.Time `json:"modified" yaml:"modified"`
+	// Credentials is a list of credential specs.
 	Credentials []CredentialStrategy `json:"credentials" yaml:"credentials"`
 }
 


### PR DESCRIPTION
This allows tools to display when a credential set was created/modified without relying upon file timestamps which aren't available when credentials are stored in the generic crud datastore.

Since we have this data on Claim, it makes sense to have it on other data that we generally store in the host environment too.

Part of #172 

Signed-off-by: Carolyn Van Slyck <carolyn.vanslyck@microsoft.com>