### PR TITLE
Rename Store.Store to Store.Save

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -28,14 +28,14 @@ func (s Store) List() ([]string, error) {
 	return s.backingStore.List()
 }
 
-// Store saves a claim. Any previous version of the claim (that is, with the same
+// Save a claim. Any previous version of the claim (that is, with the same
 // name) is overwritten.
-func (s Store) Store(claim Claim) error {
+func (s Store) Save(claim Claim) error {
 	bytes, err := json.MarshalIndent(claim, "", "  ")
 	if err != nil {
 		return err
 	}
-	return s.backingStore.Store(claim.Name, bytes)
+	return s.backingStore.Save(claim.Name, bytes)
 }
 
 // Read loads the claim with the given name from the store.

--- a/claim/claimstore_test.go
+++ b/claim/claimstore_test.go
@@ -29,7 +29,8 @@ func TestCanSaveReadAndDelete(t *testing.T) {
 	storeDir := filepath.Join(tempDir, "claimstore")
 	store := NewClaimStore(crud.NewFileSystemStore(storeDir, "json"))
 
-	is.NoError(store.Store(*claim), "Failed to store: %s", err)
+	err = store.Save(*claim)
+	is.NoError(err, "Failed to store: %s", err)
 
 	c, err := store.Read("foo")
 	is.NoError(err, "Failed to read: %s", err)
@@ -60,13 +61,13 @@ func TestCanUpdate(t *testing.T) {
 	storeDir := filepath.Join(tempDir, "claimstore")
 	store := NewClaimStore(crud.NewFileSystemStore(storeDir, "json"))
 
-	err = store.Store(*claim)
+	err = store.Save(*claim)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Millisecond)
 	claim.Update(ActionInstall, StatusSuccess)
 
-	err = store.Store(*claim)
+	err = store.Save(*claim)
 	is.NoError(err, "Failed to update")
 
 	c, err := store.Read("foo")
@@ -92,19 +93,19 @@ func TestReadAll(t *testing.T) {
 	is.NoError(err)
 	claim.Bundle = &bundle.Bundle{Name: "foobundle", Version: "0.1.0"}
 
-	is.NoError(store.Store(*claim), "Failed to store: %s", err)
+	is.NoError(store.Save(*claim), "Failed to store: %s", err)
 
 	claim2, err := New("bar")
 	is.NoError(err)
 	claim2.Bundle = &bundle.Bundle{Name: "barbundle", Version: "0.1.0"}
 
-	is.NoError(store.Store(*claim2), "Failed to store: %s", err)
+	is.NoError(store.Save(*claim2), "Failed to store: %s", err)
 
 	claim3, err := New("baz")
 	is.NoError(err)
 	claim3.Bundle = &bundle.Bundle{Name: "bazbundle", Version: "0.1.0"}
 
-	is.NoError(store.Store(*claim3), "Failed to store: %s", err)
+	is.NoError(store.Save(*claim3), "Failed to store: %s", err)
 
 	claims, err := store.ReadAll()
 	is.NoError(err, "Failed to read claims: %s", err)
@@ -133,7 +134,7 @@ func TestCanUpdateOutputs(t *testing.T) {
 		"bar-output": "bar",
 	}
 
-	err = store.Store(*claim)
+	err = store.Save(*claim)
 	is.NoError(err, "Failed to store claim")
 
 	c, err := store.Read("foo")
@@ -147,7 +148,7 @@ func TestCanUpdateOutputs(t *testing.T) {
 
 	claim.Outputs["bar-output"] = "baz"
 
-	err = store.Store(*claim)
+	err = store.Save(*claim)
 	is.NoError(err, "Failed to store claim")
 
 	c, err = store.Read("foo")

--- a/utils/crud/filesystem.go
+++ b/utils/crud/filesystem.go
@@ -39,7 +39,7 @@ func (s fileSystemStore) List() ([]string, error) {
 	return names(s.storageFiles(files)), nil
 }
 
-func (s fileSystemStore) Store(name string, data []byte) error {
+func (s fileSystemStore) Save(name string, data []byte) error {
 	filename, err := s.fullyQualifiedName(name)
 	if err != nil {
 		return err

--- a/utils/crud/filesystem_test.go
+++ b/utils/crud/filesystem_test.go
@@ -18,7 +18,7 @@ func TestFilesystemStore(t *testing.T) {
 	s := NewFileSystemStore(tmdir, "data")
 	key := "testkey"
 	val := []byte("testval")
-	is.NoError(s.Store(key, val))
+	is.NoError(s.Save(key, val))
 	list, err := s.List()
 	is.NoError(err)
 	is.Len(list, 1)

--- a/utils/crud/mongodb.go
+++ b/utils/crud/mongodb.go
@@ -55,7 +55,7 @@ func (s *mongoDBStore) List() ([]string, error) {
 	return buf, nil
 }
 
-func (s *mongoDBStore) Store(name string, data []byte) error {
+func (s *mongoDBStore) Save(name string, data []byte) error {
 	return wrapErr(s.collection.Insert(doc{name, data}))
 }
 func (s *mongoDBStore) Read(name string) ([]byte, error) {

--- a/utils/crud/store.go
+++ b/utils/crud/store.go
@@ -3,7 +3,7 @@ package crud
 // Store is a simplified interface to a key-blob store supporting CRUD operations.
 type Store interface {
 	List() ([]string, error)
-	Store(name string, data []byte) error
+	Save(name string, data []byte) error
 	Read(name string) ([]byte, error)
 	Delete(name string) error
 }

--- a/utils/crud/store_test.go
+++ b/utils/crud/store_test.go
@@ -13,7 +13,7 @@ var _ Store = &MockStore{}
 func TestMockStore(t *testing.T) {
 	s := NewMockStore()
 	is := assert.New(t)
-	is.NoError(s.Store("test", []byte("data")))
+	is.NoError(s.Save("test", []byte("data")))
 	list, err := s.List()
 	is.NoError(err)
 	is.Len(list, 1)
@@ -40,6 +40,6 @@ func (s *MockStore) List() ([]string, error) {
 	}
 	return buf, nil
 }
-func (s *MockStore) Store(name string, data []byte) error { s.data[name] = data; return nil }
-func (s *MockStore) Read(name string) ([]byte, error)     { return s.data[name], nil }
-func (s *MockStore) Delete(name string) error             { delete(s.data, name); return nil }
+func (s *MockStore) Save(name string, data []byte) error { s.data[name] = data; return nil }
+func (s *MockStore) Read(name string) ([]byte, error)    { return s.data[name], nil }
+func (s *MockStore) Delete(name string) error            { delete(s.data, name); return nil }


### PR DESCRIPTION
When a type's function is named the same as the type, the type cannot be embedded and satisfy an interface. By renaming Store.Store to Store.Save, we can embed a crud.Store in other types and have it satisfy an interface without having to fallback to type aliases.

Part of #172 

Signed-off-by: Carolyn Van Slyck <carolyn.vanslyck@microsoft.com>