### PR TITLE
Update crud.Store to support general storage

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cnabio/cnab-go/utils/crud"
 )
 
+const ItemType = "claims"
+
 // ErrClaimNotFound represents a claim not found in claim storage
 var ErrClaimNotFound = errors.New("Claim does not exist")
 
@@ -25,7 +27,7 @@ func NewClaimStore(backingStore crud.Store) Store {
 
 // List lists the names of the stored claims.
 func (s Store) List() ([]string, error) {
-	return s.backingStore.List()
+	return s.backingStore.List(ItemType)
 }
 
 // Save a claim. Any previous version of the claim (that is, with the same
@@ -35,12 +37,12 @@ func (s Store) Save(claim Claim) error {
 	if err != nil {
 		return err
 	}
-	return s.backingStore.Save(claim.Name, bytes)
+	return s.backingStore.Save(ItemType, claim.Name, bytes)
 }
 
 // Read loads the claim with the given name from the store.
 func (s Store) Read(name string) (Claim, error) {
-	bytes, err := s.backingStore.Read(name)
+	bytes, err := s.backingStore.Read(ItemType, name)
 	if err != nil {
 		if err == crud.ErrRecordDoesNotExist {
 			return Claim{}, ErrClaimNotFound
@@ -56,7 +58,7 @@ func (s Store) Read(name string) (Claim, error) {
 func (s Store) ReadAll() ([]Claim, error) {
 	claims := make([]Claim, 0)
 
-	list, err := s.backingStore.List()
+	list, err := s.backingStore.List(ItemType)
 	if err != nil {
 		return claims, err
 	}
@@ -73,5 +75,5 @@ func (s Store) ReadAll() ([]Claim, error) {
 
 // Delete deletes a claim from the store.
 func (s Store) Delete(name string) error {
-	return s.backingStore.Delete(name)
+	return s.backingStore.Delete(ItemType, name)
 }

--- a/utils/crud/filesystem_test.go
+++ b/utils/crud/filesystem_test.go
@@ -11,6 +11,8 @@ import (
 var _ Store = &fileSystemStore{}
 
 func TestFilesystemStore(t *testing.T) {
+	const claims = "claims"
+
 	is := assert.New(t)
 	tmdir, err := ioutil.TempDir("", "duffle-test-")
 	is.NoError(err)
@@ -18,15 +20,15 @@ func TestFilesystemStore(t *testing.T) {
 	s := NewFileSystemStore(tmdir, "data")
 	key := "testkey"
 	val := []byte("testval")
-	is.NoError(s.Save(key, val))
-	list, err := s.List()
+	is.NoError(s.Save(claims, key, val))
+	list, err := s.List(claims)
 	is.NoError(err)
 	is.Len(list, 1)
-	d, err := s.Read("testkey")
+	d, err := s.Read(claims, "testkey")
 	is.NoError(err)
 	is.Equal([]byte("testval"), d)
-	is.NoError(s.Delete(key))
-	list, err = s.List()
+	is.NoError(s.Delete(claims, key))
+	list, err = s.List(claims)
 	is.NoError(err)
 	is.Len(list, 0)
 }

--- a/utils/crud/mongodb.go
+++ b/utils/crud/mongodb.go
@@ -8,7 +8,7 @@ import (
 	"github.com/globalsign/mgo"
 )
 
-// MongoClaimsCollection is the name of the claims collection.
+// MongoCollectionPrefix is applied to every collection.
 const MongoCollectionPrefix = "cnab_"
 
 type mongoDBStore struct {

--- a/utils/crud/store.go
+++ b/utils/crud/store.go
@@ -2,8 +2,8 @@ package crud
 
 // Store is a simplified interface to a key-blob store supporting CRUD operations.
 type Store interface {
-	List() ([]string, error)
-	Save(name string, data []byte) error
-	Read(name string) ([]byte, error)
-	Delete(name string) error
+	List(itemType string) ([]string, error)
+	Save(itemType string, name string, data []byte) error
+	Read(itemType string, name string) ([]byte, error)
+	Delete(itemType string, name string) error
 }

--- a/utils/crud/store_test.go
+++ b/utils/crud/store_test.go
@@ -10,36 +10,70 @@ import (
 // changes. But we also provide a mock for testing.
 var _ Store = &MockStore{}
 
+const TestItemType = "test-items"
+
 func TestMockStore(t *testing.T) {
 	s := NewMockStore()
 	is := assert.New(t)
-	is.NoError(s.Save("test", []byte("data")))
-	list, err := s.List()
+	is.NoError(s.Save(TestItemType, "test", []byte("data")))
+	list, err := s.List(TestItemType)
 	is.NoError(err)
 	is.Len(list, 1)
-	data, err := s.Read("test")
+	data, err := s.Read(TestItemType, "test")
 	is.NoError(err)
 	is.Equal(data, []byte("data"))
 
 }
 
 type MockStore struct {
-	data map[string][]byte
+	data map[string]map[string][]byte
 }
 
 func NewMockStore() *MockStore {
-	return &MockStore{data: map[string][]byte{}}
+	return &MockStore{
+		data: make(map[string]map[string][]byte),
+	}
 }
 
-func (s *MockStore) List() ([]string, error) {
-	buf := make([]string, len(s.data))
-	i := 0
-	for k := range s.data {
-		buf[i] = k
-		i++
+func (s *MockStore) List(itemType string) ([]string, error) {
+	if itemData, ok := s.data[itemType]; ok {
+		buf := make([]string, len(itemData))
+		i := 0
+		for k := range itemData {
+			buf[i] = k
+			i++
+		}
+		return buf, nil
 	}
-	return buf, nil
+
+	return nil, nil
 }
-func (s *MockStore) Save(name string, data []byte) error { s.data[name] = data; return nil }
-func (s *MockStore) Read(name string) ([]byte, error)    { return s.data[name], nil }
-func (s *MockStore) Delete(name string) error            { delete(s.data, name); return nil }
+
+func (s *MockStore) Save(itemType string, name string, data []byte) error {
+	var itemData map[string][]byte
+	itemData, ok := s.data[itemType]
+	if !ok {
+		itemData = make(map[string][]byte, 1)
+		s.data[itemType] = itemData
+	}
+
+	itemData[name] = data
+	return nil
+}
+
+func (s *MockStore) Read(itemType string, name string) ([]byte, error) {
+	if itemData, ok := s.data[itemType]; ok {
+		return itemData[name], nil
+	}
+
+	return nil, nil
+}
+
+func (s *MockStore) Delete(itemType string, name string) error {
+	if itemData, ok := s.data[itemType]; ok {
+		delete(itemData, name)
+		return nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
CRUD can be used to work with any type of item, not just claims. Update the interface signature to support specifying what type of item is being stored so that the controlling code, e.g. the claim store or eventually a credential store, can say what type of data is being stored. For example "claims" or "credentials".

By altering the interface, this allows tools to avoid creating multiple instances of the same store to work with a different type of data.

Part of #172 

~🚨 This has some overlap with #174. I tried to make this PR independent but if that PR is merged first, this should be rebased and tweaked first.~ Rebase done.