### PR TITLE
Make CredentialStrategy generic

### DIFF
--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/cnabio/cnab-go/bundle"
-
+	"github.com/cnabio/cnab-go/secrets/host"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCredentialSet(t *testing.T) {
+func TestCredentialSet_ResolveCredentials(t *testing.T) {
 	is := assert.New(t)
 	if err := os.Setenv("TEST_USE_VAR", "kakapu"); err != nil {
 		t.Fatal("could not setup env")
@@ -26,11 +26,12 @@ func TestCredentialSet(t *testing.T) {
 	credset, err := Load(fmt.Sprintf("testdata/staging-%s.yaml", goos))
 	is.NoError(err)
 
-	results, err := credset.Resolve()
+	h := &host.SecretStore{}
+	results, err := credset.ResolveCredentials(h)
 	if err != nil {
 		t.Fatal(err)
 	}
-	count := 5
+	count := 4
 	is.Len(results, count, "Expected %d credentials", count)
 
 	for _, tt := range []struct {
@@ -42,7 +43,6 @@ func TestCredentialSet(t *testing.T) {
 		{name: "run_program", key: "TEST_RUN_PROGRAM", expect: "wildebeest"},
 		{name: "use_var", key: "TEST_USE_VAR", expect: "kakapu"},
 		{name: "read_file", key: "TEST_READ_FILE", expect: "serval"},
-		{name: "fallthrough", key: "TEST_FALLTHROUGH", expect: "quokka", path: "/animals/quokka.txt"},
 		{name: "plain_value", key: "TEST_PLAIN_VALUE", expect: "cassowary"},
 	} {
 		dest, ok := results[tt.name]

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -2,18 +2,13 @@ name: staging
 credentials:
   - name: read_file
     source:
-      path: testdata/someconfig.txt
+      path: $GOPATH/src/github.com/cnabio/cnab-go/credentials/testdata/someconfig.txt
   - name: run_program
     source:
       command: "echo wildebeest"
   - name: use_var
     source:
       env: TEST_USE_VAR
-      value: "this space intentionally left non-blank"
-  - name: fallthrough
-    source:
-      name: NO_SUCH_VAR
-      value: quokka
   - name: plain_value
     source:
       value: cassowary

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -2,7 +2,7 @@ name: staging
 credentials:
   - name: read_file
     source:
-      path: $GOPATH/src/github.com/cnabio/cnab-go/credentials/testdata/someconfig.txt
+      path: testdata/someconfig.txt
   - name: run_program
     source:
       command: "echo wildebeest"

--- a/credentials/testdata/staging-windows.yaml
+++ b/credentials/testdata/staging-windows.yaml
@@ -9,11 +9,6 @@ credentials:
   - name: use_var
     source:
       env: TEST_USE_VAR
-      value: "this space intentionally left non-blank"
-  - name: fallthrough
-    source:
-      name: NO_SUCH_VAR
-      value: quokka
   - name: plain_value
     source:
       value: cassowary

--- a/secrets/host/host.go
+++ b/secrets/host/host.go
@@ -1,0 +1,60 @@
+package host
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/cnabio/cnab-go/secrets"
+)
+
+const (
+	SourceEnv     = "env"
+	SourceCommand = "command"
+	SourcePath    = "path"
+	SourceValue   = "value"
+)
+
+var _ secrets.Store = &SecretStore{}
+
+type SecretStore struct{}
+
+func (h *SecretStore) Resolve(keyName string, keyValue string) (string, error) {
+	// Precedence is command, path, env, value
+	switch strings.ToLower(keyName) {
+	case SourceCommand:
+		data, err := execCmd(keyValue)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	case SourcePath:
+		data, err := ioutil.ReadFile(os.ExpandEnv(keyValue))
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	case SourceEnv:
+		var ok bool
+		data, ok := os.LookupEnv(keyValue)
+		if !ok {
+			return "", fmt.Errorf("environment variable %s is not defined", keyName)
+		}
+		return data, nil
+	case SourceValue:
+		return keyValue, nil
+	default:
+		return "", fmt.Errorf("invalid credential source: %s", keyName)
+	}
+}
+
+func execCmd(cmd string) ([]byte, error) {
+	parts := strings.Split(cmd, " ")
+	c := parts[0]
+	args := parts[1:]
+	run := exec.Command(c, args...)
+
+	return run.CombinedOutput()
+}

--- a/secrets/host/host_test.go
+++ b/secrets/host/host_test.go
@@ -1,0 +1,44 @@
+package host
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveHostCredentials(t *testing.T) {
+	is := assert.New(t)
+	if err := os.Setenv("TEST_USE_VAR", "kakapu"); err != nil {
+		t.Fatal("could not setup env")
+	}
+	defer os.Unsetenv("TEST_USE_VAR")
+
+	h := &SecretStore{}
+	for _, tt := range []struct {
+		name     string
+		keyName  string
+		keyValue string
+		expect   string
+	}{
+		{name: "run_program", keyName: SourceCommand, keyValue: "echo wildebeest", expect: "wildebeest"},
+		{name: "use_var", keyName: SourceEnv, keyValue: "TEST_USE_VAR", expect: "kakapu"},
+		{name: "read_file", keyName: SourcePath, keyValue: "../../credentials/testdata/someconfig.txt", expect: "serval"},
+		{name: "plain_value", keyName: SourceValue, keyValue: "cassowary", expect: "cassowary"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dest, err := h.Resolve(tt.keyName, tt.keyValue)
+			is.NoError(err)
+			is.Equal(tt.expect, strings.TrimSpace(dest))
+		})
+	}
+}
+
+func TestSecretStore_Resolve_InvalidSource(t *testing.T) {
+	h := &SecretStore{}
+	_, err := h.Resolve("cmd", "kv get something")
+	require.Error(t, err, "expected Resolve to return an error")
+	assert.Equal(t, "invalid credential source: cmd", err.Error())
+}

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -1,0 +1,13 @@
+package secrets
+
+// Store defines the interface for working with secret sources.
+type Store interface {
+	// Resolve a credential's value from a secret store
+	// - keyName is name of the key where the secret can be found.
+	// - keyValue is the value of the key.
+	// Examples:
+	// - keyName=env, keyValue=CONN_STRING
+	// - keyName=key, keyValue=conn-string
+	// - keyName=path, keyValue=/tmp/connstring.txt
+	Resolve(keyName string, keyValue string) (string, error)
+}


### PR DESCRIPTION
Instead of having CredentialStrategy specific to retrieving credentials from a host, with hard-coded fields for command/path/env/value, live up to the "strategy" aspect and allow for other mechanisms of finding the credential value.

I have moved the resolution of credential values to a new subpackage secrets/host which implements a new interface secrets.Store. This allows for clients, like Porter, to use plugins to retrieve secret values from external systems such as Vault while still using CredentialSets.

One breaking change is that only a single source can be specified now without fallbacks. Since this functionality was very limited to begin with, you could only specify one env, and then could only fallback to a value, and only in that order, I'm unsure if we can preserve it. If we do, it would require a breaking change to the format of the CredentialSet file structure.

Part of #172