### PR TITLE
Change license text to "The CNAB Authors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
     MIT License
 
-    Copyright (c) Microsoft Corporation. All rights reserved.
+    Copyright (c) The CNAB Authors. All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When the repository changed organizations, the license text wasn't updated.
This PR fixes that, and updates the license text to "The CNAB Authors".