### PR TITLE
feat(bundle.go): add Location validation

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -233,6 +233,15 @@ func (img InvocationImage) Validate() error {
 	}
 }
 
+// Validate the Location
+func (l Location) Validate() error {
+	forbiddenPath := "/cnab/app/outputs"
+	if strings.HasPrefix(l.Path, forbiddenPath) {
+		return fmt.Errorf("Path must not be a subpath of %q", forbiddenPath)
+	}
+	return nil
+}
+
 func validateDockerish(s string) error {
 	if !strings.Contains(s, ":") {
 		return errors.New("tag is required")

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -680,3 +680,33 @@ func TestImageDeepCopy(t *testing.T) {
 	assert.Equal(t, map[string]string{"origLabel": "newLabelValue"}, newImg.Labels)
 	assert.Equal(t, "123abcd", newImg.Digest)
 }
+
+func TestValidateLocation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		location Location
+		err      string
+	}{{
+		name:     "no path",
+		location: Location{},
+	}, {
+		name:     "ok path",
+		location: Location{Path: "/path/to/thing"},
+	}, {
+		name:     "error path",
+		location: Location{Path: "/cnab/app/outputs/thing"},
+		err:      `Path must not be a subpath of "/cnab/app/outputs"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.location.Validate()
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Adds validation for the `Location` property (used by `Parameter`s and `Credential`s)

Implementation corresponding to proposed spec change in https://github.com/cnabio/cnab-spec/pull/330