### PR TITLE
ref(action): remove status+json action

### DIFF
--- a/action/wellknown.go
+++ b/action/wellknown.go
@@ -34,11 +34,6 @@ type Status struct {
 	Driver driver.Driver
 }
 
-// StatusJSON runs a status+JSON action on a CNAB bundle.
-type StatusJSON struct {
-	Driver driver.Driver
-}
-
 // Run executes a dry-run action in an image
 func (i *DryRun) Run(c *claim.Claim, creds credentials.Set, opCfgs ...OperationConfigFunc) error {
 	return (&RunCustom{Driver: i.Driver, Action: ActionDryRun}).Run(c, creds, opCfgs...)

--- a/action/wellknown_test.go
+++ b/action/wellknown_test.go
@@ -1,6 +1,6 @@
 package action
 
-// makes sure DryRun, Help, Log, Status, StatusJSON implements Action interface
+// makes sure DryRun, Help, Log, Status implements Action interface
 var _ Action = &DryRun{}
 var _ Action = &Help{}
 var _ Action = &Log{}


### PR DESCRIPTION
When reviewing https://github.com/cnabio/cnab-go/pull/154 (albeit, tardily) I noticed what appeared to be remnants of a status+json well-known action.  I didn't see an implementation of the Action interface for this, so I assumed the remnants should just be removed.  Please advise if the opposite is true and we intend to add an implementation and offer it as a first-class well-known action.