### PR TITLE
feat(claim): add Result validation

### DIFF
--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -174,6 +174,7 @@ func TestMarshal_AllFields(t *testing.T) {
 }
 
 func TestClaimSchema(t *testing.T) {
+	t.Skip("This test is pending an alternate, offline-friendly implementation; see https://github.com/cnabio/cnab-go/issues/194")
 	claimBytes, err := json.Marshal(exampleClaim)
 	assert.NoError(t, err, "failed to json.Marshal the claim")
 

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -136,6 +136,33 @@ func TestValidateExampleClaim(t *testing.T) {
 		`claim validation failed: invalid schema version "not-semver": Invalid Semantic Version`)
 }
 
+func TestValidate_InvalidResult(t *testing.T) {
+	claim := exampleClaim
+
+	t.Run("if result is empty, validation should fail", func(t *testing.T) {
+		claim.Result = Result{}
+		err := claim.Validate()
+		assert.EqualError(t, err, "claim validation failed: the action must be provided")
+	})
+
+	t.Run("if result has empty action, validation should fail", func(t *testing.T) {
+		claim.Result = Result{
+			Status: StatusSuccess,
+		}
+		err := claim.Validate()
+		assert.EqualError(t, err, "claim validation failed: the action must be provided")
+	})
+
+	t.Run("if result has invalid status, validation should fail", func(t *testing.T) {
+		claim.Result = Result{
+			Action: "install",
+			Status: "invalidStatus",
+		}
+		err := claim.Validate()
+		assert.EqualError(t, err, "claim validation failed: invalid status: invalidStatus")
+	})
+}
+
 func TestMarshal_AllFields(t *testing.T) {
 	bytes, err := json.Marshal(exampleClaim)
 	assert.NoError(t, err, "failed to json.Marshal claim")

--- a/claim/testdata/claim.default.json
+++ b/claim/testdata/claim.default.json
@@ -1,1 +1,1 @@
-{"schemaVersion":"v1.0.0-WD","installation":"my_claim","revision":"revision","created":"1983-04-18T01:02:03.000000004Z","modified":"1983-04-18T01:02:03.000000004Z","bundle":null,"result":{"message":"","action":"unknown","status":"unknown"}}
+{"schemaVersion":"v1.0.0-WD","installation":"my_claim","revision":"revision","created":"1983-04-18T01:02:03.000000004Z","modified":"1983-04-18T01:02:03.000000004Z","bundle":null,"result":{"action":"unknown","status":"unknown"}}


### PR DESCRIPTION
* adds validation for the `Result` object, including its `Status` property, according to the [Claims Spec](https://github.com/cnabio/cnab-spec/blob/master/400-claims.md)

Note for reviewers:  Do we want to modify the function signature for the [Update](https://github.com/cnabio/cnab-go/blob/master/claim/claim.go#L85) method on a `Claim` to return an `error`?  We can then check to be sure the supplied `action` and `status` form a valid `Result`; if not, we would return an error.