### PR TITLE
Improve matching of not found errors 

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cnabio/cnab-go/utils/crud"
 )
@@ -46,7 +47,7 @@ func (s Store) Save(claim Claim) error {
 func (s Store) Read(name string) (Claim, error) {
 	bytes, err := s.backingStore.Read(ItemType, name)
 	if err != nil {
-		if err == crud.ErrRecordDoesNotExist {
+		if strings.Contains(err.Error(), crud.ErrRecordDoesNotExist.Error()) {
 			return Claim{}, ErrClaimNotFound
 		}
 		return Claim{}, err

--- a/credentials/credstore.go
+++ b/credentials/credstore.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cnabio/cnab-go/utils/crud"
 )
@@ -45,7 +46,7 @@ func (s Store) Save(cred CredentialSet) error {
 func (s Store) Read(name string) (CredentialSet, error) {
 	bytes, err := s.backingStore.Read(ItemType, name)
 	if err != nil {
-		if err == crud.ErrRecordDoesNotExist {
+		if strings.Contains(err.Error(), crud.ErrRecordDoesNotExist.Error()) {
 			return CredentialSet{}, ErrNotFound
 		}
 		return CredentialSet{}, err

--- a/credentials/credstore_test.go
+++ b/credentials/credstore_test.go
@@ -1,0 +1,22 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cnabio/cnab-go/utils/crud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCredentialStore_HandlesNotFoundError(t *testing.T) {
+	mockStore := crud.NewMockStore()
+	mockStore.ReadMock = func(itemType string, name string) (bytes []byte, err error) {
+		// Change the default error message to test that we are checking
+		// inside the error message and not matching it exactly
+		return nil, errors.New("wrapping error message: " + crud.ErrRecordDoesNotExist.Error())
+	}
+	cs := NewCredentialStore(mockStore)
+
+	_, err := cs.Read("missing cred set")
+	assert.EqualError(t, err, ErrNotFound.Error())
+}

--- a/utils/crud/backingstore_test.go
+++ b/utils/crud/backingstore_test.go
@@ -19,11 +19,11 @@ func TestBackingStore_Read(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.data[TestItemType] = map[string][]byte{"key1": []byte("value1")}
+			s.data[testItemType] = map[string][]byte{"key1": []byte("value1")}
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
-			val, err := bs.Read(TestItemType, "key1")
+			val, err := bs.Read(testItemType, "key1")
 			require.NoError(t, err, "expected Read to succeed")
 			assert.Equal(t, "value1", string(val), "Read returned the wrong data")
 
@@ -57,7 +57,7 @@ func TestBackingStore_Store(t *testing.T) {
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
-			err := bs.Save(TestItemType, "key1", []byte("value1"))
+			err := bs.Save(testItemType, "key1", []byte("value1"))
 			require.NoError(t, err, "expected Store to succeed")
 
 			connectCount, err := s.GetConnectCount()
@@ -72,7 +72,7 @@ func TestBackingStore_Store(t *testing.T) {
 				assert.Equal(t, 0, closeCount, "Close should not be automatically called")
 			}
 
-			val, err := bs.Read(TestItemType, "key1")
+			val, err := bs.Read(testItemType, "key1")
 			require.NoError(t, err, "expected Read to succeed")
 			assert.Equal(t, "value1", string(val), "stored value did not survive the round trip")
 
@@ -107,14 +107,14 @@ func TestBackingStore_List(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.data[TestItemType] = map[string][]byte{
+			s.data[testItemType] = map[string][]byte{
 				"key1": []byte("value1"),
 				"key2": []byte("value2"),
 			}
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
-			results, err := bs.List(TestItemType)
+			results, err := bs.List(testItemType)
 			require.NoError(t, err, "expected List to succeed")
 			require.Contains(t, results, "key1")
 			require.Contains(t, results, "key2")
@@ -146,11 +146,11 @@ func TestBackingStore_Delete(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.data[TestItemType] = map[string][]byte{"key1": []byte("value1")}
+			s.data[testItemType] = map[string][]byte{"key1": []byte("value1")}
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
-			err := bs.Delete(TestItemType, "key1")
+			err := bs.Delete(testItemType, "key1")
 			require.NoError(t, err, "expected Delete to succeed")
 
 			connectCount, err := s.GetConnectCount()
@@ -165,7 +165,7 @@ func TestBackingStore_Delete(t *testing.T) {
 				assert.Equal(t, 0, closeCount, "Close should not be automatically called")
 			}
 
-			val, _ := bs.Read(TestItemType, "key1")
+			val, _ := bs.Read(testItemType, "key1")
 			assert.Empty(t, val, "Delete should have removed the entry")
 		})
 	}
@@ -183,14 +183,14 @@ func TestBackingStore_ReadAll(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.data[TestItemType] = map[string][]byte{
+			s.data[testItemType] = map[string][]byte{
 				"key1": []byte("value1"),
 				"key2": []byte("value2"),
 			}
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
-			results, err := bs.ReadAll(TestItemType)
+			results, err := bs.ReadAll(testItemType)
 			require.NoError(t, err, "expected ReadAll to succeed")
 			assert.Contains(t, results, []byte("value1"))
 			assert.Contains(t, results, []byte("value2"))

--- a/utils/crud/mock_store_test.go
+++ b/utils/crud/mock_store_test.go
@@ -1,0 +1,19 @@
+package crud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockStore(t *testing.T) {
+	s := NewMockStore()
+	is := assert.New(t)
+	is.NoError(s.Save(testItemType, "test", []byte("data")))
+	list, err := s.List(testItemType)
+	is.NoError(err)
+	is.Len(list, 1)
+	data, err := s.Read(testItemType, "test")
+	is.NoError(err)
+	is.Equal(data, []byte("data"))
+}


### PR DESCRIPTION
* **Export crud.MockStore and allow mocking errors**
    The MockStore struct is very useful for tests outside of the crud package, since it has an in-memory implementation of the crud.Store interface. This adds the ability to mock errors to test out how code that wrap the store handle edge cases and then exports the struct.
* **Improve matching of not found errors**
    Previously in the claim and credential store, we matched exactly on the underlying not found errors from the crud store. This doesn't work well when the store may be being wrapped in layers, for example in Porter's case the store error is wrapped in an net/rpc error so the error doesn't match exactly.

    This changes the matching to allow for how errors are usually wrapped, with an error message appended and the original message preserved within the error message.

    We care because it allows the claim store and credential store to detect "not found" scenarios and present a more clear error message such as "Claim not found" instead of "file not found" when in many cases the claim may not be represented as a file anyway.
