### PR TITLE
ref(bundle.go): only validate/return value if param applies to provided action

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -170,11 +170,16 @@ type Action struct {
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values. An error is returned when the parameter value does not pass
-// the schema validation or a required parameter is missing.
-func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+// the schema validation or a required parameter is missing, assuming the parameter applies to the provided action.
+func ValuesOrDefaults(vals map[string]interface{}, b *Bundle, action string) (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 
 	for name, param := range b.Parameters {
+		// If the parameter doesn't apply to the provided action,
+		// skip validation and do not attempt to include in the returned list
+		if !param.AppliesTo(action) {
+			continue
+		}
 		s, ok := b.Definitions[param.Definition]
 		if !ok {
 			return res, fmt.Errorf("unable to find definition for %s", name)

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -214,17 +214,18 @@ func TestValuesOrDefaults_Required(t *testing.T) {
 }
 
 func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
-	is := assert.New(t)
+	// vals represent user-supplied parameter values
 	vals := map[string]interface{}{
 		"param-with-default-and-override": true,
 	}
+
 	b := &Bundle{
 		Definitions: map[string]*definition.Schema{
 			"param-with-default-not-applicable": {
 				Type:    "string",
 				Default: "foo",
 			},
-			"required-param-not-applicable": {
+			"required-param-with-default-not-applicable": {
 				Type: "string",
 			},
 			"param-with-default": {
@@ -243,8 +244,8 @@ func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
 					"uninstall",
 				},
 			},
-			"required-param-not-applicable": {
-				Definition: "required-param-not-applicable",
+			"required-param-with-default-not-applicable": {
+				Definition: "required-param-with-default-not-applicable",
 				Required:   true,
 				ApplyTo: []string{
 					"uninstall",
@@ -260,11 +261,13 @@ func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
 	}
 
 	res, err := ValuesOrDefaults(vals, b, "install")
-	is.NoError(err)
-	is.Equal(true, res["param-with-default-and-override"])
-	is.Equal(false, res["param-with-default"])
-	is.Equal(nil, res["param-with-default-not-applicable"])
-	is.Equal(nil, res["required-param-with-default-not-applicable"])
+	require.NoError(t, err)
+
+	expected := map[string]interface{}{
+		"param-with-default":              false,
+		"param-with-default-and-override": true,
+	}
+	require.Equal(t, expected, res)
 }
 
 func TestValidateVersionTag(t *testing.T) {

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -225,7 +225,7 @@ func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
 				Type:    "string",
 				Default: "foo",
 			},
-			"required-param-with-default-not-applicable": {
+			"required-param-not-applicable": {
 				Type: "string",
 			},
 			"param-with-default": {
@@ -244,8 +244,8 @@ func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
 					"uninstall",
 				},
 			},
-			"required-param-with-default-not-applicable": {
-				Definition: "required-param-with-default-not-applicable",
+			"required-param-not-applicable": {
+				Definition: "required-param-not-applicable",
 				Required:   true,
 				ApplyTo: []string{
 					"uninstall",


### PR DESCRIPTION
* adds functionality in the `ValuesOrDefaults` method to skip parameter validation and value lookup if it does not apply to the provided action
* in doing so, updates the function signature to now pass in the action

 