### PR TITLE
fix(docker.go): check nil pointer case; export ApplyConfigurationOptions

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -55,6 +55,10 @@ func (d *Driver) AddConfigurationOptions(opts ...ConfigurationOption) {
 // GetContainerConfig returns a copy of the container configuration
 // used by the driver during container exec
 func (d *Driver) GetContainerConfig() (container.Config, error) {
+	if d.containerCfg == nil {
+		return container.Config{}, nil
+	}
+
 	cpy, err := copystructure.Copy(*d.containerCfg)
 	if err != nil {
 		return container.Config{}, err
@@ -71,6 +75,10 @@ func (d *Driver) GetContainerConfig() (container.Config, error) {
 // GetContainerHostConfig returns a copy of the container host configuration
 // used by the driver during container exec
 func (d *Driver) GetContainerHostConfig() (container.HostConfig, error) {
+	if d.containerHostCfg == nil {
+		return container.HostConfig{}, nil
+	}
+
 	cpy, err := copystructure.Copy(*d.containerHostCfg)
 	if err != nil {
 		return container.HostConfig{}, err
@@ -200,7 +208,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	}
 
 	d.containerHostCfg = &container.HostConfig{}
-	if err := d.applyConfigurationOptions(); err != nil {
+	if err := d.ApplyConfigurationOptions(); err != nil {
 		return driver.OperationResult{}, err
 	}
 
@@ -293,7 +301,8 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	return opResult, err
 }
 
-func (d *Driver) applyConfigurationOptions() error {
+// ApplyConfigurationOptions applies the configuration options set on the driver
+func (d *Driver) ApplyConfigurationOptions() error {
 	for _, opt := range d.dockerConfigurationOptions {
 		if err := opt(d.containerCfg, d.containerHostCfg); err != nil {
 			return err

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -14,11 +14,21 @@ func TestDriver_GetConfigurationOptions(t *testing.T) {
 	is.NotNil(d)
 	is.True(d.Handles(driver.ImageTypeDocker))
 
-	t.Run("no configuration options", func(t *testing.T) {
+	t.Run("uninitialized configuration options", func(t *testing.T) {
+		containerCfg, err := d.GetContainerConfig()
+		is.NoError(err)
+		is.Equal(container.Config{}, containerCfg)
+
+		containerHostCfg, err := d.GetContainerHostConfig()
+		is.NoError(err)
+		is.Equal(container.HostConfig{}, containerHostCfg)
+	})
+
+	t.Run("empty configuration options", func(t *testing.T) {
 		d.containerCfg = &container.Config{}
 		d.containerHostCfg = &container.HostConfig{}
 
-		err := d.applyConfigurationOptions()
+		err := d.ApplyConfigurationOptions()
 		is.NoError(err)
 
 		cfg, err := d.GetContainerConfig()
@@ -39,7 +49,7 @@ func TestDriver_GetConfigurationOptions(t *testing.T) {
 			return nil
 		})
 
-		err := d.applyConfigurationOptions()
+		err := d.ApplyConfigurationOptions()
 		is.NoError(err)
 
 		expectedContainerCfg := container.Config{


### PR DESCRIPTION
* Avoids nil pointer panic if configuration uninitialized at time of retrieval
* Exports `ApplyConfigurationOptions` method, handy for consumers of this pkg

Q for reviewers: Should we explicitly error out if the configuration is uninitialized?  Or return an empty struct and no error, as is currently done in this PR?