### PR TITLE
Fix ULID generation

### DIFF
--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -226,6 +226,7 @@ func TestULID(t *testing.T) {
 				if strings.Compare(next, last) != 1 {
 					t.Fatal("generated a ULID that was not monotonically increasing")
 				}
+				last = next
 			}
 		}()
 	}


### PR DESCRIPTION
* The entropy generator needs to be reused between ULIDs to ensure that each ULID is monotonically increasing.
* We should use the monotonic function so that ULIDs generated during the same millisecond can still be sorted.
* Use a mutex in ULID since math.Rand is not thread-safe.

I was seeing in unit tests where I was generating ULIDs back-to-back that they were not sorting correctly. After digging through the issue queue, it turns out the example on the README of the ulid library we use is not appropriate to copy and use. I believe this is what they recommend based on their replies to a few issues.