### PR TITLE
Fix linter settings and errors

### DIFF
--- a/action/install_test.go
+++ b/action/install_test.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // makes sure Install implements Action interface

--- a/action/operation_configs_test.go
+++ b/action/operation_configs_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cnabio/cnab-go/driver"
 )
 
 func TestOperationConfigs_ApplyConfig(t *testing.T) {

--- a/action/run_custom_test.go
+++ b/action/run_custom_test.go
@@ -5,11 +5,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // makes sure RunCustom implements Action interface

--- a/action/uninstall_test.go
+++ b/action/uninstall_test.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // makes sure Uninstall implements Action interface

--- a/action/upgrade_test.go
+++ b/action/upgrade_test.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cnabio/cnab-go/claim"
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cnabio/cnab-go/claim"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // makes sure Upgrade implements Action interface

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -8,10 +8,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cnabio/cnab-go/bundle/definition"
-	"github.com/cnabio/cnab-go/schema"
 	"github.com/docker/go/canonical/json"
 	pkgErrors "github.com/pkg/errors"
+
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/schema"
 )
 
 // CNABSpecVersion represents the CNAB Spec version of the Bundle

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -6,12 +6,12 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle/definition"
-	"github.com/cnabio/cnab-go/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/cnabio/cnab-go/bundle/definition"
+	"github.com/cnabio/cnab-go/schema"
 )
 
 func TestReadTopLevelProperties(t *testing.T) {

--- a/claim/claimstore_test.go
+++ b/claim/claimstore_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cnabio/cnab-go/bundle"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/utils/crud"
 )
 
 func TestCanSaveReadAndDelete(t *testing.T) {

--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -7,9 +7,10 @@ import (
 	"io/ioutil"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/secrets"
-	"gopkg.in/yaml.v2"
 )
 
 // Set is an actual set of resolved credentials.

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/secrets/host"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCredentialSet_ResolveCredentials(t *testing.T) {

--- a/credentials/credstore_test.go
+++ b/credentials/credstore_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/utils/crud"
 )
 
 func TestCredentialStore_HandlesNotFoundError(t *testing.T) {

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/driver"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCommandDriverOutputs(t *testing.T) {

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	unix_path "path"
 
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/docker/cli/cli/command"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/distribution/reference"
@@ -22,6 +21,8 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/registry"
 	"github.com/mitchellh/copystructure"
+
+	"github.com/cnabio/cnab-go/driver"
 )
 
 // Driver is capable of running Docker invocation images using Docker itself.

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -3,10 +3,11 @@ package docker
 import (
 	"testing"
 
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/driver"
 )
 
 func TestDriver_GetConfigurationOptions(t *testing.T) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cnabio/cnab-go/bundle"
 	"github.com/docker/go/canonical/json"
+
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 // ImageType constants provide some of the image types supported

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/bundle"
 )
 
 var _ Driver = &DebugDriver{}

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle"
-	"github.com/cnabio/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/driver"
 )
 
 func TestDriver_Run(t *testing.T) {

--- a/golangci.yml
+++ b/golangci.yml
@@ -4,16 +4,16 @@ run:
 linters:
   disable-all: true
   enable:
-  - gofmt
-  - goimports
-  - golint
-  - gosimple
-  - ineffassign
-  - misspell
-  - unused
-  - deadcode
-  - govet
+    - gofmt
+    - goimports
+    - golint
+    - gosimple
+    - ineffassign
+    - misspell
+    - unused
+    - deadcode
+    - govet
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/radu-matei/cnab-go
+    local-prefixes: github.com/cnabio/cnab-go

--- a/packager/export.go
+++ b/packager/export.go
@@ -8,10 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/docker/docker/pkg/archive"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/loader"
 	"github.com/cnabio/cnab-go/imagestore"
-	"github.com/docker/docker/pkg/archive"
 )
 
 type Exporter struct {

--- a/packager/import.go
+++ b/packager/import.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/docker/pkg/archive"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/loader"
-	"github.com/docker/docker/pkg/archive"
 )
 
 // Importer is responsible for importing a file

--- a/packager/import_test.go
+++ b/packager/import_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle/loader"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/bundle/loader"
 )
 
 func TestImport(t *testing.T) {


### PR DESCRIPTION
The `goimports` settings in the linter options were wrong, meaning `goimports` was not running properly.

This PR fixes that, as well as the linter errors.