### PR TITLE
Use GoTool Task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,22 +1,10 @@
 pool:
   vmImage: 'Ubuntu 16.04'
 
-variables:
-  GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  GOROOT: '/usr/local/go1.13' # Go installation path
-  GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
-  modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)' # Path to the module's code
-
 steps:
-- script: |
-    mkdir -p '$(GOBIN)'
-    mkdir -p '$(GOPATH)/pkg'
-    mkdir -p '$(modulePath)'
-    shopt -s extglob
-    mv !(gopath) '$(modulePath)'
-    echo '##vso[task.prependpath]$(GOBIN)'
-    echo '##vso[task.prependpath]$(GOROOT)/bin'
-  displayName: 'Set up the Go workspace'
+- task: GoTool@0
+  inputs:
+    version: '1.13.10'
 
 - script: |
     go version
@@ -24,7 +12,7 @@ steps:
     make bootstrap fetch-schemas build lint coverage
     GOOS=windows make build
     GOOS=darwin make build 
-  workingDirectory: '$(modulePath)'
+  workingDirectory: '$(System.DefaultWorkingDirectory)'
   displayName: 'Get dependencies, build, test'
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Azure Devops moved where new versions of go (1.11+) are installed and no longer recommends using the scripts we had for setting up go. They have a Task that they want you to use to pick the exact version of go you want and then use it to go get your code.

Our builds were failing because as part of this GOROOT moved from `/usr/local/go1.13` to `/usr/local/go1.13.PATCH` which since we don't actually specify patch, was a bit hard to intuit. 😅

https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/go?view=azure-devops&tabs=go-current#set-up-go