### PR TITLE
Stop on nonzero exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,13 @@ ifndef HAS_GOCOV_XML
 	go get github.com/AlekSi/gocov-xml
 endif
 ifndef HAS_GOCOV
-	go get -u github.com/axw/gocov/gocov
+	go get github.com/axw/gocov@v1.0.0
 endif
 ifndef HAS_GO_JUNIT_REPORT
-	go get github.com/jstemmer/go-junit-report
+	go get github.com/jstemmer/go-junit-report@v0.9.1
 endif
 ifndef HAS_PACKR2
-	go get -u github.com/gobuffalo/packr/v2/packr2
+	go get github.com/gobuffalo/packr/v2/packr2@v2.8.0
 endif
 	@# go get to install global tools with modules modify our dependencies. Reset them back
 	git checkout go.mod go.sum

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ steps:
     version: '1.13.10'
 
 - script: |
+    set -euo pipefail
     go version
     go get sigs.k8s.io/kind@v0.6.0
     make bootstrap fetch-schemas build lint coverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,20 @@ steps:
 - task: GoTool@0
   inputs:
     version: '1.13.10'
+  displayName: 'Install Go'
 
 - script: |
-    set -euo pipefail
-    go version
+    set -xeuo pipefail
+    mkdir -p /home/vsts/go/bin/
+    echo "##vso[task.prependpath]/home/vsts/go/bin/"
+  displayName: 'Configure Go'
+
+- script: |
+    go env
+    go mod download
     go get sigs.k8s.io/kind@v0.6.0
-    make bootstrap fetch-schemas build lint coverage
+    sudo make bootstrap
+    make fetch-schemas build lint coverage
     GOOS=windows make build
     GOOS=darwin make build 
   workingDirectory: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
When you embed bash in yaml, make sure to stop on nonzero exit codes. Otherwise builds pass when they should have failed...

Signed-off-by: Carolyn Van Slyck <carolyn.vanslyck@microsoft.com>