### PR TITLE
Fail build take two

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifndef HAS_GOCOV_XML
 	go get github.com/AlekSi/gocov-xml
 endif
 ifndef HAS_GOCOV
-	go get github.com/axw/gocov@v1.0.0
+	go get github.com/axw/gocov/gocov@v1.0.0
 endif
 ifndef HAS_GO_JUNIT_REPORT
 	go get github.com/jstemmer/go-junit-report@v0.9.1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ steps:
   displayName: 'Configure Go'
 
 - script: |
+    set -xeuo pipefail
     go env
     go mod download
     go get sigs.k8s.io/kind@v0.6.0


### PR DESCRIPTION
When I fixed adding go/bin to PATH, I accidentally moved instead of copied the lines to fail the script. Adding it back. 🤦‍♀️ 

So this does a check that I can yet again fail the build, and then fixes the installation of gocov, which isn't working on master, so we aren't publishing coverage results.