### PR TITLE
Store installation names

### DIFF
--- a/claim/installation.go
+++ b/claim/installation.go
@@ -7,8 +7,7 @@ import (
 	"time"
 )
 
-// Installation is a non-storage construct representing an installation of a
-// bundle.
+// Installation represents the installation of a bundle.
 type Installation struct {
 	Name string
 	Claims

--- a/utils/crud/mock_store_test.go
+++ b/utils/crud/mock_store_test.go
@@ -7,11 +7,6 @@ import (
 )
 
 func TestMockStoreWithGroups(t *testing.T) {
-	// This is the structure used with claims
-	// claims/
-	// - INSTALLATION/
-	//   - CLAIMID.json
-
 	s := NewMockStore()
 	is := assert.New(t)
 	is.NoError(s.Save(testItemType, testGroup, "test", []byte("data")))
@@ -22,15 +17,11 @@ func TestMockStoreWithGroups(t *testing.T) {
 
 	data, err := s.Read(testItemType, "test")
 	is.NoError(err)
-	is.Equal(data, []byte("data"))
+	is.Equal([]byte("data"), data)
 
 	data, err = s.Read(testItemType, "not-exist")
 	is.EqualError(err, ErrRecordDoesNotExist.Error())
 	is.Empty(data)
-
-	groups, err := s.List(testItemType, "")
-	is.NoError(err)
-	is.Equal(groups, []string{testGroup})
 }
 
 func TestMockStoreWithoutGroups(t *testing.T) {


### PR DESCRIPTION
Do not rely on inferring the names from the storage layer, e.g. the directory above the claims, that leaks the abstraction and makes implementing the store more difficult. Have the claim store be responsible for tracking the names of installed bundles explicitly.

I ran into this while implementing storage on top of object storage, where the installation wasn't encoded in the directory structure, but instead using tags on the objects. It just doesn't make sense to have to calculate what the installation names are at the crud.Store layer, when each implementation may be using a different technique.