### PR TITLE
Ensure a single connect per logical query

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -130,6 +130,12 @@ func (s Store) ListOutputs(resultID string) ([]string, error) {
 }
 
 func (s Store) ReadInstallation(installation string) (Installation, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Installation{}, err
+	}
+
 	claims, err := s.ReadAllClaims(installation)
 	if err != nil {
 		return Installation{}, err
@@ -153,6 +159,12 @@ func (s Store) ReadInstallation(installation string) (Installation, error) {
 }
 
 func (s Store) ReadInstallationStatus(installation string) (Installation, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Installation{}, err
+	}
+
 	claimIds, err := s.ListClaims(installation)
 	if err != nil {
 		return Installation{}, err
@@ -191,6 +203,12 @@ func (s Store) ReadInstallationStatus(installation string) (Installation, error)
 }
 
 func (s Store) ReadAllInstallationStatus() ([]Installation, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return nil, err
+	}
+
 	names, err := s.ListInstallations()
 	if err != nil {
 		return nil, err
@@ -254,6 +272,12 @@ func (s Store) ReadAllClaims(installation string) ([]Claim, error) {
 }
 
 func (s Store) ReadLastClaim(installation string) (Claim, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Claim{}, err
+	}
+
 	claimIds, err := s.backingStore.List(ItemTypeClaims, installation)
 	if err != nil {
 		return Claim{}, s.handleNotExistsError(err, ErrInstallationNotFound)
@@ -306,12 +330,24 @@ func (s Store) ReadAllResults(claimID string) ([]Result, error) {
 // ReadLastOutputs returns the most recent (last) value of each output associated
 // with the installation.
 func (s Store) ReadLastOutputs(installation string) (Outputs, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Outputs{}, err
+	}
+
 	return s.readLastOutputs(installation, "")
 }
 
 // ReadLastOutput returns the most recent value (last) of the specified Output associated
 // with the installation.
 func (s Store) ReadLastOutput(installation string, name string) (Output, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Output{}, err
+	}
+
 	outputs, err := s.readLastOutputs(installation, name)
 	if err != nil {
 		return Output{}, err
@@ -380,6 +416,12 @@ func (s Store) readLastOutputs(installation string, filterOutput string) (Output
 }
 
 func (s Store) ReadLastResult(claimID string) (Result, error) {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return Result{}, err
+	}
+
 	resultIDs, err := s.backingStore.List(ItemTypeResults, claimID)
 	if err != nil {
 		return Result{}, s.handleNotExistsError(err, ErrClaimNotFound)
@@ -417,6 +459,12 @@ func (s Store) ReadOutput(c Claim, r Result, outputName string) (Output, error) 
 }
 
 func (s Store) SaveClaim(c Claim) error {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return err
+	}
+
 	bytes, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
 		return err
@@ -466,6 +514,12 @@ func (s Store) SaveOutput(o Output) error {
 }
 
 func (s Store) DeleteInstallation(installation string) error {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return err
+	}
+
 	claimIds, err := s.ListClaims(installation)
 	if err != nil {
 		return err
@@ -483,6 +537,12 @@ func (s Store) DeleteInstallation(installation string) error {
 }
 
 func (s Store) DeleteClaim(claimID string) error {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return err
+	}
+
 	resultIds, err := s.ListResults(claimID)
 	if err != nil {
 		return err
@@ -500,6 +560,12 @@ func (s Store) DeleteClaim(claimID string) error {
 }
 
 func (s Store) DeleteResult(resultID string) error {
+	handleClose, err := s.backingStore.HandleConnect()
+	defer handleClose()
+	if err != nil {
+		return err
+	}
+
 	outputNames, err := s.ListOutputs(resultID)
 	if err != nil {
 		return err

--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -107,6 +107,7 @@ func (s Store) ListResults(claimID string) ([]string, error) {
 		return nil, err
 	}
 
+	sort.Strings(results)
 	return results, nil
 }
 
@@ -125,7 +126,7 @@ func (s Store) ListOutputs(resultID string) ([]string, error) {
 	for i, fullName := range outputNames {
 		outputNames[i] = strings.TrimLeft(fullName, resultID+"-")
 	}
-
+	sort.Strings(outputNames)
 	return outputNames, nil
 }
 

--- a/claim/claimstore_test.go
+++ b/claim/claimstore_test.go
@@ -163,6 +163,7 @@ func assertSingleConnection(t *testing.T, datastore crud.MockStore) {
 	require.NoError(t, err, "GetCloseCount failed")
 	assert.Equal(t, 1, closes, "expected a single close")
 }
+
 func TestCanSaveReadAndDelete(t *testing.T) {
 	is := assert.New(t)
 	must := require.New(t)

--- a/claim/claimstore_test.go
+++ b/claim/claimstore_test.go
@@ -66,13 +66,8 @@ var b64decode = func(src []byte) ([]byte, error) {
 //   RESULT_ID_2/
 //     RESULT_ID_2_OUTPUT_1
 //     RESULT_ID_2_OUTPUT_2
-func generateClaimData(t *testing.T) (Provider, func() error) {
-	tempDir, err := ioutil.TempDir("", "cnabtest")
-	require.NoError(t, err, "Failed to create temp dir")
-	cleanup := func() error { return os.RemoveAll(tempDir) }
-
-	storeDir := filepath.Join(tempDir, "claimstore")
-	backingStore := crud.NewFileSystemStore(storeDir, NewClaimStoreFileExtensions())
+func generateClaimData(t *testing.T) (Provider, crud.MockStore) {
+	backingStore := crud.NewMockStore()
 	cp := NewClaimStore(backingStore, nil, nil)
 
 	bun := bundle.Bundle{
@@ -117,7 +112,7 @@ func generateClaimData(t *testing.T) (Provider, func() error) {
 	createOutput := func(c Claim, r Result, name string) Output {
 		o := NewOutput(c, r, name, []byte(c.Action+" "+name))
 
-		err = cp.SaveOutput(o)
+		err := cp.SaveOutput(o)
 		require.NoError(t, err, "SaveOutput failed")
 
 		return o
@@ -153,9 +148,21 @@ func generateClaimData(t *testing.T) (Provider, func() error) {
 
 	createClaim(baz, ActionInstall)
 
-	return cp, cleanup
+	backingStore.ResetCounts()
+	return cp, backingStore
 }
 
+func assertSingleConnection(t *testing.T, datastore crud.MockStore) {
+	t.Helper()
+
+	connects, err := datastore.GetConnectCount()
+	require.NoError(t, err, "GetConnectCount failed")
+	assert.Equal(t, 1, connects, "expected a single connect")
+
+	closes, err := datastore.GetCloseCount()
+	require.NoError(t, err, "GetCloseCount failed")
+	assert.Equal(t, 1, closes, "expected a single close")
+}
 func TestCanSaveReadAndDelete(t *testing.T) {
 	is := assert.New(t)
 	must := require.New(t)
@@ -230,18 +237,21 @@ func TestCanUpdate(t *testing.T) {
 }
 
 func TestClaimStore_Installations(t *testing.T) {
-	cp, cleanup := generateClaimData(t)
-	defer cleanup()
+	cp, datastore := generateClaimData(t)
 
 	t.Run("ListInstallations", func(t *testing.T) {
+		datastore.ResetCounts()
 		installations, err := cp.ListInstallations()
 		require.NoError(t, err, "ListInstallations failed")
 
 		require.Len(t, installations, 3, "Expected 3 installations")
 		assert.Equal(t, []string{"bar", "baz", "foo"}, installations)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadAllInstallationStatus", func(t *testing.T) {
+		datastore.ResetCounts()
 		installations, err := cp.ReadAllInstallationStatus()
 		require.NoError(t, err, "ReadAllInstallationStatus failed")
 
@@ -254,9 +264,12 @@ func TestClaimStore_Installations(t *testing.T) {
 		assert.Equal(t, "bar", bar.Name)
 		assert.Equal(t, "baz", baz.Name)
 		assert.Equal(t, "foo", foo.Name)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadInstallationStatus", func(t *testing.T) {
+		datastore.ResetCounts()
 		foo, err := cp.ReadInstallationStatus("foo")
 		require.NoError(t, err, "ReadInstallationStatus failed")
 
@@ -267,6 +280,8 @@ func TestClaimStore_Installations(t *testing.T) {
 		lastClaim, err := foo.GetLastClaim()
 		require.NoError(t, err, "GetLastClaim failed")
 		assert.Equal(t, ActionUninstall, lastClaim.Action)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadInstallationStatus - invalid installation", func(t *testing.T) {
@@ -276,6 +291,7 @@ func TestClaimStore_Installations(t *testing.T) {
 	})
 
 	t.Run("ReadInstallation", func(t *testing.T) {
+		datastore.ResetCounts()
 		foo, err := cp.ReadInstallation("foo")
 		require.NoError(t, err, "ReadInstallation failed")
 
@@ -287,6 +303,8 @@ func TestClaimStore_Installations(t *testing.T) {
 		assert.Equal(t, ActionUpgrade, foo.Claims[1].Action)
 		assert.Equal(t, "test", foo.Claims[2].Action)
 		assert.Equal(t, ActionUninstall, foo.Claims[3].Action)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadInstallation - invalid installation", func(t *testing.T) {
@@ -297,11 +315,12 @@ func TestClaimStore_Installations(t *testing.T) {
 }
 
 func TestClaimStore_DeleteInstallation(t *testing.T) {
-	cp, cleanup := generateClaimData(t)
-	defer cleanup()
+	cp, datastore := generateClaimData(t)
 
 	err := cp.DeleteInstallation("foo")
 	require.NoError(t, err, "DeleteInstallation failed")
+
+	assertSingleConnection(t, datastore)
 
 	names, err := cp.ListInstallations()
 	require.NoError(t, err, "ListInstallations failed")
@@ -312,10 +331,10 @@ func TestClaimStore_DeleteInstallation(t *testing.T) {
 }
 
 func TestClaimStore_Claims(t *testing.T) {
-	cp, cleanup := generateClaimData(t)
-	defer cleanup()
+	cp, datastore := generateClaimData(t)
 
 	t.Run("ReadAllClaims", func(t *testing.T) {
+		datastore.ResetCounts()
 		claims, err := cp.ReadAllClaims("foo")
 		require.NoError(t, err, "Failed to read claims: %s", err)
 
@@ -324,6 +343,8 @@ func TestClaimStore_Claims(t *testing.T) {
 		assert.Equal(t, ActionUpgrade, claims[1].Action)
 		assert.Equal(t, "test", claims[2].Action)
 		assert.Equal(t, ActionUninstall, claims[3].Action)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadAllClaims - invalid installation", func(t *testing.T) {
@@ -333,10 +354,13 @@ func TestClaimStore_Claims(t *testing.T) {
 	})
 
 	t.Run("ListClaims", func(t *testing.T) {
+		datastore.ResetCounts()
 		claims, err := cp.ListClaims("foo")
 		require.NoError(t, err, "Failed to read claims: %s", err)
 
 		require.Len(t, claims, 4, "Expected 4 claims")
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ListClaims - invalid installation", func(t *testing.T) {
@@ -352,11 +376,14 @@ func TestClaimStore_Claims(t *testing.T) {
 		assert.NotEmpty(t, claims, "no claims were found")
 		claimID := claims[0]
 
+		datastore.ResetCounts()
 		c, err := cp.ReadClaim(claimID)
 		require.NoError(t, err, "ReadClaim failed")
 
 		assert.Equal(t, "foo", c.Installation)
 		assert.Equal(t, ActionInstall, c.Action)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadClaim - invalid claim", func(t *testing.T) {
@@ -365,11 +392,14 @@ func TestClaimStore_Claims(t *testing.T) {
 	})
 
 	t.Run("ReadLastClaim", func(t *testing.T) {
+		datastore.ResetCounts()
 		c, err := cp.ReadLastClaim("bar")
 		require.NoError(t, err, "ReadLastClaim failed")
 
 		assert.Equal(t, "bar", c.Installation)
 		assert.Equal(t, ActionInstall, c.Action)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadLastClaim - invalid installation", func(t *testing.T) {
@@ -380,8 +410,7 @@ func TestClaimStore_Claims(t *testing.T) {
 }
 
 func TestClaimStore_Results(t *testing.T) {
-	cp, cleanup := generateClaimData(t)
-	defer cleanup()
+	cp, datastore := generateClaimData(t)
 
 	barClaims, err := cp.ListClaims("bar")
 	require.NoError(t, err, "ListClaims failed")
@@ -394,9 +423,13 @@ func TestClaimStore_Results(t *testing.T) {
 	unfinishedClaimID := bazClaims[1] // this claim doesn't have any results yet
 
 	t.Run("ListResults", func(t *testing.T) {
+		datastore.ResetCounts()
+
 		results, err := cp.ListResults(claimID)
 		require.NoError(t, err, "ListResults failed")
 		assert.Len(t, results, 2, "expected 2 results")
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ListResults - unfinished claim", func(t *testing.T) {
@@ -406,12 +439,16 @@ func TestClaimStore_Results(t *testing.T) {
 	})
 
 	t.Run("ReadAllResults", func(t *testing.T) {
+		datastore.ResetCounts()
+
 		results, err := cp.ReadAllResults(claimID)
 		require.NoError(t, err, "ReadAllResults failed")
 		assert.Len(t, results, 2, "expected 2 results")
 
 		assert.Equal(t, StatusRunning, results[0].Status)
 		assert.Equal(t, StatusSucceeded, results[1].Status)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadAllResults - unfinished claim", func(t *testing.T) {
@@ -421,10 +458,14 @@ func TestClaimStore_Results(t *testing.T) {
 	})
 
 	t.Run("ReadLastResult", func(t *testing.T) {
+		datastore.ResetCounts()
+
 		r, err := cp.ReadLastResult(claimID)
 		require.NoError(t, err, "ReadLastResult failed")
 
 		assert.Equal(t, StatusSucceeded, r.Status)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadLastResult - unfinished claim", func(t *testing.T) {
@@ -439,10 +480,13 @@ func TestClaimStore_Results(t *testing.T) {
 
 		resultID := results[0]
 
+		datastore.ResetCounts()
 		r, err := cp.ReadResult(resultID)
 		require.NoError(t, err, "ReadResult failed")
 
 		assert.Equal(t, StatusRunning, r.Status)
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadResult - invalid result", func(t *testing.T) {
@@ -453,8 +497,7 @@ func TestClaimStore_Results(t *testing.T) {
 }
 
 func TestClaimStore_Outputs(t *testing.T) {
-	cp, cleanup := generateClaimData(t)
-	defer cleanup()
+	cp, datastore := generateClaimData(t)
 
 	fooClaims, err := cp.ReadAllClaims("foo")
 	require.NoError(t, err, "ReadAllClaims failed")
@@ -477,12 +520,15 @@ func TestClaimStore_Outputs(t *testing.T) {
 	resultIDWithoutOutputs := barResult.ID
 
 	t.Run("ListOutputs", func(t *testing.T) {
+		datastore.ResetCounts()
 		outputs, err := cp.ListOutputs(resultID)
 		require.NoError(t, err, "ListResults failed")
 		assert.Len(t, outputs, 2, "expected 2 outputs")
 
 		assert.Equal(t, "output1", outputs[0])
 		assert.Equal(t, "output2", outputs[1])
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ListOutputs - no outputs", func(t *testing.T) {
@@ -492,6 +538,7 @@ func TestClaimStore_Outputs(t *testing.T) {
 	})
 
 	t.Run("ReadLastOutputs", func(t *testing.T) {
+		datastore.ResetCounts()
 		outputs, err := cp.ReadLastOutputs("foo")
 
 		require.NoError(t, err, "GetLastOutputs failed")
@@ -504,6 +551,8 @@ func TestClaimStore_Outputs(t *testing.T) {
 		gotOutput2, hasOutput2 := outputs.GetByName("output2")
 		assert.True(t, hasOutput2, "should have found output2")
 		assert.Equal(t, "upgrade output2", string(gotOutput2.Value), "did not find the most recent value for output2")
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadLastOutputs - invalid installation", func(t *testing.T) {
@@ -513,10 +562,13 @@ func TestClaimStore_Outputs(t *testing.T) {
 	})
 
 	t.Run("ReadLastOutput", func(t *testing.T) {
+		datastore.ResetCounts()
 		o, err := cp.ReadLastOutput("foo", "output1")
 
 		require.NoError(t, err, "GetLastOutputs failed")
 		assert.Equal(t, "upgrade output1", string(o.Value), "did not find the most recent value for output1")
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadLastOutput - invalid installation", func(t *testing.T) {
@@ -531,6 +583,8 @@ func TestClaimStore_Outputs(t *testing.T) {
 		installResult, err := cp.ReadLastResult(installClaim.ID)
 		require.NoError(t, err, "ReadLastResult failed")
 
+		datastore.ResetCounts()
+
 		o, err := cp.ReadOutput(installClaim, installResult, "output1")
 		require.NoError(t, err, "ReadOutput failed")
 
@@ -538,6 +592,8 @@ func TestClaimStore_Outputs(t *testing.T) {
 		assert.Equal(t, installResult.ID, o.result.ID, "output.Result is not set")
 		assert.Equal(t, installClaim.ID, o.result.claim.ID, "output.Result.Claim is not set")
 		assert.Equal(t, "install output1", string(o.Value))
+
+		assertSingleConnection(t, datastore)
 	})
 
 	t.Run("ReadOutput - no outputs", func(t *testing.T) {

--- a/utils/crud/backingstore_test.go
+++ b/utils/crud/backingstore_test.go
@@ -19,10 +19,8 @@ func TestBackingStore_Read(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.groups[testItemType] = map[string][]string{
-				testGroup: {"key1"},
-			}
-			s.data[testItemType] = map[string][]byte{"key1": []byte("value1")}
+			s.Save(testItemType, testGroup, "key1", []byte("value1"))
+			s.ResetCounts()
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
@@ -110,13 +108,9 @@ func TestBackingStore_List(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.groups[testItemType] = map[string][]string{
-				testGroup: {"key1"},
-			}
-			s.data[testItemType] = map[string][]byte{
-				"key1": []byte("value1"),
-				"key2": []byte("value2"),
-			}
+			s.Save(testItemType, testGroup, "key1", []byte("value1"))
+			s.Save(testItemType, "", "key2", []byte("value2"))
+			s.ResetCounts()
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
@@ -152,10 +146,8 @@ func TestBackingStore_Delete(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.groups[testItemType] = map[string][]string{
-				testGroup: {"key1"},
-			}
-			s.data[testItemType] = map[string][]byte{"key1": []byte("value1")}
+			s.Save(testItemType, testGroup, "key1", []byte("value1"))
+			s.ResetCounts()
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 
@@ -192,13 +184,9 @@ func TestBackingStore_ReadAll(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewMockStore()
-			s.groups[testItemType] = map[string][]string{
-				testGroup: {"key1"},
-			}
-			s.data[testItemType] = map[string][]byte{
-				"key1": []byte("value1"),
-				"key2": []byte("value2"),
-			}
+			s.Save(testItemType, testGroup, "key1", []byte("value1"))
+			s.Save(testItemType, "", "key2", []byte("value2"))
+
 			bs := NewBackingStore(s)
 			bs.AutoClose = tc.autoclose
 

--- a/utils/crud/mock_store.go
+++ b/utils/crud/mock_store.go
@@ -205,7 +205,7 @@ func (s MockStore) ResetCounts() {
 func (s MockStore) setCount(count string, value int) {
 	s.data[path.Join(mockStoreType, count)] = &item{
 		itemType: mockStoreType,
-		name:     connectCount,
+		name:     count,
 		data:     []byte(strconv.Itoa(value)),
 	}
 }


### PR DESCRIPTION
When the claimstore executes multiple queries against the crud store to execute a logical query, e.g. ReadInstallationStatus, ensure that it only results in a single call to Connect.

I've updated the claim store tests to use our MockStore so that we can assert on connects/closes. The MockStore was using nested maps that was hard to understand so I refactored it so it's easier to understand.