### PR TITLE
Initialize storage from backing stores

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver"
 	"github.com/cnabio/cnab-go/driver/debug"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 
 	"github.com/hashicorp/go-multierror"
@@ -993,7 +992,7 @@ func TestGetOutputsGeneratedByAction(t *testing.T) {
 
 func TestSaveAction(t *testing.T) {
 	t.Run("save output", func(t *testing.T) {
-		cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+		cp := claim.NewMockStore(nil, nil)
 		c := newClaim(claim.ActionInstall)
 		r, err := c.NewResult(claim.StatusSucceeded)
 		require.NoError(t, err, "NewResult failed")
@@ -1023,7 +1022,7 @@ func TestSaveAction(t *testing.T) {
 	})
 
 	t.Run("do not save output", func(t *testing.T) {
-		cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+		cp := claim.NewMockStore(nil, nil)
 		c := newClaim(claim.ActionInstall)
 		r, err := c.NewResult(claim.StatusSucceeded)
 		require.NoError(t, err, "NewResult failed")

--- a/action/example_install_test.go
+++ b/action/example_install_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver"
 	"github.com/cnabio/cnab-go/driver/lookup"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
@@ -22,7 +21,7 @@ func Example_install() {
 	}
 
 	// Use an in-memory store with no encryption
-	cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+	cp := claim.NewMockStore(nil, nil)
 
 	// Create the action that will execute the operation
 	a := action.New(d, cp)

--- a/action/example_invoke_test.go
+++ b/action/example_invoke_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cnabio/cnab-go/action"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver/lookup"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
@@ -20,7 +19,7 @@ func Example_invoke() {
 	}
 
 	// Use an in-memory store with no encryption
-	cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+	cp := claim.NewMockStore(nil, nil)
 
 	// Save an existing claim for the install action which has already taken place
 	// This sets up data for us to use during our upgrade example

--- a/action/example_running_status_test.go
+++ b/action/example_running_status_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cnabio/cnab-go/action"
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver/lookup"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
@@ -41,7 +40,7 @@ func Example_runningStatus() {
 	}
 
 	// Use an in-memory store with no encryption
-	cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+	cp := claim.NewMockStore(nil, nil)
 
 	// Save an existing claim for the install action which has already taken place
 	// This sets up data for us to use during our upgrade example

--- a/action/example_upgrade_test.go
+++ b/action/example_upgrade_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cnabio/cnab-go/claim"
 	"github.com/cnabio/cnab-go/driver"
 	"github.com/cnabio/cnab-go/driver/lookup"
-	"github.com/cnabio/cnab-go/utils/crud"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
@@ -22,7 +21,7 @@ func Example_upgrade() {
 	}
 
 	// Use an in-memory store with no encryption
-	cp := claim.NewClaimStore(crud.NewMockStore(), nil, nil)
+	cp := claim.NewMockStore(nil, nil)
 
 	// Save an existing claim for the install action which has already taken place
 	// This sets up data for us to use during our upgrade example

--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -45,7 +45,7 @@ type Store struct {
 
 // NewClaimStore creates a persistent store for claims using the specified
 // backing key-blob store.
-func NewClaimStore(store crud.Store, encrypt EncryptionHandler, decrypt EncryptionHandler) Store {
+func NewClaimStore(store *crud.BackingStore, encrypt EncryptionHandler, decrypt EncryptionHandler) Store {
 	if encrypt == nil {
 		encrypt = noOpEncryptionHandler
 	}
@@ -55,7 +55,7 @@ func NewClaimStore(store crud.Store, encrypt EncryptionHandler, decrypt Encrypti
 	}
 
 	return Store{
-		backingStore: crud.NewBackingStore(store),
+		backingStore: store,
 		encrypt:      encrypt,
 		decrypt:      decrypt,
 	}
@@ -78,6 +78,11 @@ type EncryptionHandler func([]byte) ([]byte, error)
 // noOpEncryptHandler is used when no handler is specified.
 var noOpEncryptionHandler = func(data []byte) ([]byte, error) {
 	return data, nil
+}
+
+// GetBackingStore returns the data store behind this claim store.
+func (s Store) GetBackingStore() *crud.BackingStore {
+	return s.backingStore
 }
 
 func (s Store) ListInstallations() ([]string, error) {

--- a/claim/mock_store.go
+++ b/claim/mock_store.go
@@ -1,0 +1,10 @@
+package claim
+
+import (
+	"github.com/cnabio/cnab-go/utils/crud"
+)
+
+// NewMockStore creates a mock claim store for unit testing.
+func NewMockStore(encrypt EncryptionHandler, decrypt EncryptionHandler) Store {
+	return NewClaimStore(crud.NewBackingStore(crud.NewMockStore()), encrypt, decrypt)
+}

--- a/credentials/credstore.go
+++ b/credentials/credstore.go
@@ -22,10 +22,15 @@ type Store struct {
 
 // NewCredentialStore creates a persistent store for credential sets using the specified
 // backing key-blob store.
-func NewCredentialStore(store crud.Store) Store {
+func NewCredentialStore(store *crud.BackingStore) Store {
 	return Store{
-		backingStore: crud.NewBackingStore(store),
+		backingStore: store,
 	}
+}
+
+// GetBackingStore returns the data store behind this credentials store.
+func (s Store) GetBackingStore() *crud.BackingStore {
+	return s.backingStore
 }
 
 // List lists the names of the stored credential sets.

--- a/credentials/credstore_test.go
+++ b/credentials/credstore_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestCredentialStore_HandlesNotFoundError(t *testing.T) {
-	mockStore := crud.NewMockStore()
+	cs := NewMockStore()
+	mockStore := cs.GetBackingStore().GetDataStore().(crud.MockStore)
 	mockStore.ReadMock = func(itemType string, name string) (bytes []byte, err error) {
 		// Change the default error message to test that we are checking
 		// inside the error message and not matching it exactly
 		return nil, errors.New("wrapping error message: " + crud.ErrRecordDoesNotExist.Error())
 	}
-	cs := NewCredentialStore(mockStore)
 
 	_, err := cs.Read("missing cred set")
 	assert.EqualError(t, err, ErrNotFound.Error())

--- a/credentials/mock_store.go
+++ b/credentials/mock_store.go
@@ -1,0 +1,10 @@
+package credentials
+
+import (
+	"github.com/cnabio/cnab-go/utils/crud"
+)
+
+// NewMockStore creates a mock credentials store for unit testing.
+func NewMockStore() Store {
+	return NewCredentialStore(crud.NewBackingStore(crud.NewMockStore()))
+}

--- a/utils/crud/backingstore.go
+++ b/utils/crud/backingstore.go
@@ -23,13 +23,13 @@ type BackingStore struct {
 	close func() error
 
 	// backingStore being wrapped.
-	backingStore Store
+	datastore Store
 }
 
 func NewBackingStore(store Store) *BackingStore {
 	backingStore := BackingStore{
-		AutoClose:    true,
-		backingStore: store,
+		AutoClose: true,
+		datastore: store,
 	}
 
 	if connectable, ok := store.(HasConnect); ok {
@@ -41,6 +41,12 @@ func NewBackingStore(store Store) *BackingStore {
 	}
 
 	return &backingStore
+}
+
+// GetStore returns the data store, e.g. filesystem, mongodb, managed by this
+// wrapper.
+func (s *BackingStore) GetDataStore() Store {
+	return s.datastore
 }
 
 func (s *BackingStore) Connect() error {
@@ -76,7 +82,7 @@ func (s *BackingStore) List(itemType string, group string) ([]string, error) {
 		return nil, err
 	}
 
-	return s.backingStore.List(itemType, group)
+	return s.datastore.List(itemType, group)
 }
 
 func (s *BackingStore) Save(itemType string, group string, name string, data []byte) error {
@@ -86,7 +92,7 @@ func (s *BackingStore) Save(itemType string, group string, name string, data []b
 		return err
 	}
 
-	return s.backingStore.Save(itemType, group, name, data)
+	return s.datastore.Save(itemType, group, name, data)
 }
 
 func (s *BackingStore) Read(itemType string, name string) ([]byte, error) {
@@ -96,7 +102,7 @@ func (s *BackingStore) Read(itemType string, name string) ([]byte, error) {
 		return nil, err
 	}
 
-	return s.backingStore.Read(itemType, name)
+	return s.datastore.Read(itemType, name)
 }
 
 // ReadAll retrieves all the items with the specified prefix
@@ -131,7 +137,7 @@ func (s *BackingStore) Delete(itemType string, name string) error {
 		return err
 	}
 
-	return s.backingStore.Delete(itemType, name)
+	return s.datastore.Delete(itemType, name)
 }
 
 func (s *BackingStore) shouldAutoConnect() bool {


### PR DESCRIPTION
Do not create backing stores internally for a claim or credential storage. Instead have the caller pass in the backing store so that the caller can control the lifetime and connection properties, such as AutoConnect, themselves.

For example, in porter this let's us use the same instance of a backing store independently and with a claim store, while keeping the connection open during the migration of the claims directory to match the new claims spec.