### PR TITLE
Fix error listing outputs when bundle definition changed

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -378,6 +378,7 @@ func (s Store) readLastOutputs(installation string, filterOutput string) (Output
 	}
 
 	for _, c := range claims {
+		scopedClaim := c
 		resultIds, err := s.ListResults(c.ID)
 		if err != nil {
 			return Outputs{}, err
@@ -386,7 +387,7 @@ func (s Store) readLastOutputs(installation string, filterOutput string) (Output
 			results = append(results, Result{
 				ID:      resultID,
 				ClaimID: c.ID,
-				claim:   &c,
+				claim:   &scopedClaim,
 			})
 		}
 	}


### PR DESCRIPTION
When an output was removed, an error was generated listing the outputs for an installation:

```
could not determine if the output "user" is sensitive: output "user" not defined
```

After digging into the code where I traverse the last generated output value, I found that I was capturing the value of a for loop variable without first making it a local variable inside the for loop. Go doesn't do closures the same way other languages do, and what this really ended up doing was giving every instance the same reference. Not very useful.