### PR TITLE
feat(docker): add verification of image digest(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,9 @@ endif
 	git checkout go.mod go.sum
 
 .PHONY: coverage
-coverage:
+coverage: compile-integration-tests
 	./e2e-kind.sh
+
+.PHONY: compile-integration-tests
+compile-integration-tests:
+	@go test -tags=integration -run nothing ./...

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -428,7 +428,7 @@ func (d *Driver) validateImageDigest(image bundle.InvocationImage, repoDigests [
 	repoDigest := repoDigests[0]
 	ref, err := reference.ParseNormalizedNamed(repoDigest)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to parse repo digest %s", repoDigest)
 	}
 	digestRef, ok := ref.(reference.Digested)
 	if !ok {

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -112,7 +112,7 @@ func TestDriver_ValidateImageDigestFail(t *testing.T) {
 	assert.Error(t, err)
 	// Not asserting actual image digests to support arbitrary integration test images
 	assert.Contains(t, err.Error(),
-		fmt.Sprintf("content digest mismatch: image %s has digest(s)", op.Image.Image))
+		fmt.Sprintf("content digest mismatch: image %s has digest", op.Image.Image))
 	assert.Contains(t, err.Error(),
-		fmt.Sprintf("but the digest should be %s according to the bundle file", badDigest))
+		fmt.Sprintf("but the value should be %s according to the bundle file", badDigest))
 }

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -110,7 +110,7 @@ func TestDriver_ValidateImageDigest(t *testing.T) {
 
 		err := d.validateImageDigest(image, repoDigests)
 		assert.EqualError(t, err,
-			"content digest mismatch: image myreg/myimg has digest(s) [sha256:deadbeef] but the digest should be sha256:livebeef according to the bundle file")
+			"content digest mismatch: image myreg/myimg has digest sha256:deadbeef but the value should be sha256:livebeef according to the bundle file")
 	})
 
 	t.Run("image digest exists - a match exists", func(t *testing.T) {

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -88,7 +88,7 @@ func TestDriver_GetConfigurationOptions(t *testing.T) {
 
 func TestDriver_ValidateImageDigest(t *testing.T) {
 	repoDigests := []string{
-		"myreg/myimg@sha256:deadbeef",
+		"myreg/myimg@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a",
 	}
 
 	t.Run("no image digest", func(t *testing.T) {
@@ -106,11 +106,11 @@ func TestDriver_ValidateImageDigest(t *testing.T) {
 
 		image := bundle.InvocationImage{}
 		image.Image = "myreg/myimg"
-		image.Digest = "sha256:livebeef"
+		image.Digest = "sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321"
 
 		err := d.validateImageDigest(image, repoDigests)
-		assert.EqualError(t, err,
-			"content digest mismatch: image myreg/myimg has digest sha256:deadbeef but the value should be sha256:livebeef according to the bundle file")
+		assert.NotNil(t, err, "expected an error")
+		assert.Contains(t, err.Error(), "content digest mismatch")
 	})
 
 	t.Run("image digest exists - a match exists", func(t *testing.T) {
@@ -118,9 +118,24 @@ func TestDriver_ValidateImageDigest(t *testing.T) {
 
 		image := bundle.InvocationImage{}
 		image.Image = "myreg/myimg"
-		image.Digest = "sha256:deadbeef"
+		image.Digest = "sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
 
 		err := d.validateImageDigest(image, repoDigests)
 		assert.NoError(t, err)
+	})
+
+	t.Run("image digest exists - more than one repo digest exists", func(t *testing.T) {
+		d := &Driver{}
+
+		image := bundle.InvocationImage{}
+		image.Image = "myreg/myimg"
+		image.Digest = "sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
+
+		repoDigests = append(repoDigests,
+			"myreg/myimg@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321")
+
+		err := d.validateImageDigest(image, repoDigests)
+		assert.NotNil(t, err, "expected an error")
+		assert.EqualError(t, err, "image myreg/myimg has more than one repo digest")
 	})
 }


### PR DESCRIPTION
* Adds invocation image digest verification per the [CNAB Spec](https://github.com/cnabio/cnab-spec/blob/master/101-bundle-json.md#invocation-images) to the Docker driver.

The specific part of the spec that this PR currently implements is the following line:

`If a contentDigest field is present, a runtime MUST validate the image digest prior to executing an action.`

I didn't see how this would be done generically, e.g. outside of specific driver implementations, hence implementing it on the Docker driver only.  Am I right here?  If so, perhaps a follow-up could implement similar in the kubernetes driver.

Note some remaining TODOs/Qs inline.  Feel free to respond/answer in the form of code review comments.