### PR TITLE
Add schemaVersion to credentialSet

### DIFF
--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -13,10 +13,17 @@ import (
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
-// CNABSpecVersion represents the CNAB Spec version of the Credentials
-// that this library implements
-// This value is prefixed with e.g. `cnab-credentials-` so isn't itself valid semver.
-var CNABSpecVersion string = "cnab-credentialsets-1.0.0-DRAFT-b6c701f"
+const (
+	// DefaultSchemaVersion is the default SchemaVersion value
+	// set on new CredentialSet instances, and is the semver portion
+	// of CNABSpecVersion.
+	DefaultSchemaVersion = schema.Version("1.0.0-DRAFT+b6c701f")
+
+	// CNABSpecVersion represents the CNAB Spec version of the Credentials
+	// that this library implements
+	// This value is prefixed with e.g. `cnab-credentials-` so isn't itself valid semver.
+	CNABSpecVersion string = "cnab-credentialsets-" + string(DefaultSchemaVersion)
+)
 
 // CredentialSet represents a collection of credentials
 type CredentialSet struct {
@@ -32,14 +39,18 @@ type CredentialSet struct {
 	Credentials []valuesource.Strategy `json:"credentials" yaml:"credentials"`
 }
 
-// GetDefaultSchemaVersion returns the default semver CNAB schema version of the CredentialSet
-// that this library implements
-func GetDefaultSchemaVersion() (schema.Version, error) {
-	ver, err := schema.GetSemver(CNABSpecVersion)
-	if err != nil {
-		return "", err
+// NewCredentialSet creates a new CredentialSet with the required fields initialized.
+func NewCredentialSet(name string, creds ...valuesource.Strategy) CredentialSet {
+	now := time.Now()
+	cs := CredentialSet{
+		SchemaVersion: DefaultSchemaVersion,
+		Name:          name,
+		Created:       now,
+		Modified:      now,
+		Credentials:   creds,
 	}
-	return ver, nil
+
+	return cs
 }
 
 // Load a CredentialSet from a file at a given path.

--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -20,7 +20,7 @@ var CNABSpecVersion string = "cnab-credentialsets-1.0.0-DRAFT-b6c701f"
 
 // CredentialSet represents a collection of credentials
 type CredentialSet struct {
-	// SchemaVersion is the version of the claim schema.
+	// SchemaVersion is the version of the credential-set schema.
 	SchemaVersion schema.Version `json:"schemaVersion" yaml:"schemaVersion"`
 	// Name is the name of the credentialset.
 	Name string `json:"name" yaml:"name"`

--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -8,12 +8,20 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/cnabio/cnab-go/bundle"
+	"github.com/cnabio/cnab-go/schema"
 	"github.com/cnabio/cnab-go/secrets"
 	"github.com/cnabio/cnab-go/valuesource"
 )
 
+// CNABSpecVersion represents the CNAB Spec version of the Credentials
+// that this library implements
+// This value is prefixed with e.g. `cnab-credentials-` so isn't itself valid semver.
+var CNABSpecVersion string = "cnab-credentialsets-1.0.0-DRAFT-b6c701f"
+
 // CredentialSet represents a collection of credentials
 type CredentialSet struct {
+	// SchemaVersion is the version of the claim schema.
+	SchemaVersion schema.Version `json:"schemaVersion" yaml:"schemaVersion"`
 	// Name is the name of the credentialset.
 	Name string `json:"name" yaml:"name"`
 	// Created timestamp of the credentialset.
@@ -22,6 +30,16 @@ type CredentialSet struct {
 	Modified time.Time `json:"modified" yaml:"modified"`
 	// Credentials is a list of credential specs.
 	Credentials []valuesource.Strategy `json:"credentials" yaml:"credentials"`
+}
+
+// GetDefaultSchemaVersion returns the default semver CNAB schema version of the CredentialSet
+// that this library implements
+func GetDefaultSchemaVersion() (schema.Version, error) {
+	ver, err := schema.GetSemver(CNABSpecVersion)
+	if err != nil {
+		return "", err
+	}
+	return ver, nil
 }
 
 // Load a CredentialSet from a file at a given path.

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cnabio/cnab-go/secrets/host"
 )
@@ -25,6 +26,10 @@ func TestCredentialSet_ResolveCredentials(t *testing.T) {
 	}
 	credset, err := Load(fmt.Sprintf("testdata/staging-%s.yaml", goos))
 	is.NoError(err)
+
+	version, err := GetDefaultSchemaVersion()
+	require.NoError(t, err, "GetDefaultSchemaVersion failed")
+	is.Equal(version, credset.SchemaVersion)
 
 	h := &host.SecretStore{}
 	results, err := credset.ResolveCredentials(h)

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cnabio/cnab-go/schema"
 	"github.com/cnabio/cnab-go/secrets/host"
+	"github.com/cnabio/cnab-go/valuesource"
 )
 
 func TestCredentialSet_ResolveCredentials(t *testing.T) {
@@ -26,10 +28,6 @@ func TestCredentialSet_ResolveCredentials(t *testing.T) {
 	}
 	credset, err := Load(fmt.Sprintf("testdata/staging-%s.yaml", goos))
 	is.NoError(err)
-
-	version, err := GetDefaultSchemaVersion()
-	require.NoError(t, err, "GetDefaultSchemaVersion failed")
-	is.Equal(version, credset.SchemaVersion)
 
 	h := &host.SecretStore{}
 	results, err := credset.ResolveCredentials(h)
@@ -54,4 +52,28 @@ func TestCredentialSet_ResolveCredentials(t *testing.T) {
 		is.True(ok)
 		is.Equal(tt.expect, strings.TrimSpace(dest))
 	}
+}
+
+func TestCNABSpecVersion(t *testing.T) {
+	version, err := schema.GetSemver(CNABSpecVersion)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultSchemaVersion, version)
+}
+
+func TestNewCredentialSet(t *testing.T) {
+	cs := NewCredentialSet("mycreds",
+		valuesource.Strategy{
+			Name: "password",
+			Source: valuesource.Source{
+				Key:   "env",
+				Value: "MY_PASSWORD",
+			},
+		})
+
+	assert.Equal(t, "mycreds", cs.Name, "Name was not set")
+	assert.NotEmpty(t, cs.Created, "Created was not set")
+	assert.NotEmpty(t, cs.Modified, "Modified was not set")
+	assert.Equal(t, cs.Created, cs.Modified, "Created and Modified should have the same timestamp")
+	assert.Equal(t, DefaultSchemaVersion, cs.SchemaVersion, "SchemaVersion was not set")
+	assert.Len(t, cs.Credentials, 1, "Credentials should be initialized with 1 value")
 }

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -1,4 +1,5 @@
 name: staging
+schemaVersion: "1.0.0-DRAFT-b6c701f"
 credentials:
   - name: read_file
     source:

--- a/credentials/testdata/staging-unix.yaml
+++ b/credentials/testdata/staging-unix.yaml
@@ -1,5 +1,5 @@
 name: staging
-schemaVersion: "1.0.0-DRAFT-b6c701f"
+schemaVersion: "1.0.0-DRAFT+b6c701f"
 credentials:
   - name: read_file
     source:

--- a/credentials/testdata/staging-windows.yaml
+++ b/credentials/testdata/staging-windows.yaml
@@ -1,4 +1,5 @@
 name: staging
+schemaVersion: "1.0.0-DRAFT-b6c701f"
 credentials:
   - name: read_file
     source:

--- a/credentials/testdata/staging-windows.yaml
+++ b/credentials/testdata/staging-windows.yaml
@@ -1,5 +1,5 @@
 name: staging
-schemaVersion: "1.0.0-DRAFT-b6c701f"
+schemaVersion: "1.0.0-DRAFT+b6c701f"
 credentials:
   - name: read_file
     source:


### PR DESCRIPTION
Add a schemaVersion field to credentialSet so that we can identify the spec version that the credential set adheres to. This was very useful for claims, we use it for data migrations when the claim spec changes, and it is best to have it _before_ we need to change the spec. Worst case we never change the spec again and we all win. 😄

The last change to the credential-set spec was https://github.com/cnabio/cnab-spec/releases/tag/cnab-credentialsets-1.0.0-DRAFT+b6c701f
