### PR TITLE
Fix invocation image digest validation

### DIFF
--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
@@ -109,10 +110,8 @@ func TestDriver_ValidateImageDigestFail(t *testing.T) {
 	docker := &Driver{}
 
 	_, err := docker.Run(op)
-	assert.Error(t, err)
+	require.Error(t, err, "expected an error")
 	// Not asserting actual image digests to support arbitrary integration test images
 	assert.Contains(t, err.Error(),
-		fmt.Sprintf("content digest mismatch: image %s has digest", op.Image.Image))
-	assert.Contains(t, err.Error(),
-		fmt.Sprintf("but the value should be %s according to the bundle file", badDigest))
+		fmt.Sprintf("content digest mismatch: invocation image %s was defined in the bundle with the digest %s but no matching repoDigest was found upon inspecting the image", op.Image.Image, badDigest))
 }

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/driver"
@@ -87,8 +88,12 @@ func TestDriver_GetConfigurationOptions(t *testing.T) {
 }
 
 func TestDriver_ValidateImageDigest(t *testing.T) {
+	// Mimic the digests created when a bundle is pushed with cnab-to-oci
+	// there is one for the original invocation image and another
+	// for the relocated invocation image inside the bundle repository
 	repoDigests := []string{
-		"myreg/myimg@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a",
+		"myreg/mybun-installer:v1.0.0",
+		"myreg/mybun@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a",
 	}
 
 	t.Run("no image digest", func(t *testing.T) {
@@ -101,15 +106,15 @@ func TestDriver_ValidateImageDigest(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("image digest exists - no match exists", func(t *testing.T) {
+	t.Run("image digest exists - no match found", func(t *testing.T) {
 		d := &Driver{}
 
 		image := bundle.InvocationImage{}
-		image.Image = "myreg/myimg"
+		image.Image = "myreg/mybun@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
 		image.Digest = "sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321"
 
 		err := d.validateImageDigest(image, repoDigests)
-		assert.NotNil(t, err, "expected an error")
+		require.NotNil(t, err, "expected an error")
 		assert.Contains(t, err.Error(), "content digest mismatch")
 	})
 
@@ -117,39 +122,24 @@ func TestDriver_ValidateImageDigest(t *testing.T) {
 		d := &Driver{}
 
 		image := bundle.InvocationImage{}
-		image.Image = "myreg/myimg"
+		image.Image = "myreg/mybun@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
 		image.Digest = "sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321"
 
-		badRepoDigests := []string{"myreg/myimg@sha256:deadbeef"}
+		badRepoDigests := []string{"myreg/mybun@sha256:deadbeef"}
 
 		err := d.validateImageDigest(image, badRepoDigests)
-		assert.NotNil(t, err, "expected an error")
-		assert.EqualError(t, err, "unable to parse repo digest myreg/myimg@sha256:deadbeef")
+		require.NotNil(t, err, "expected an error")
+		assert.Contains(t, err.Error(), "unable to parse repo digest")
 	})
 
-	t.Run("image digest exists - more than one repo digest exists", func(t *testing.T) {
+	t.Run("image digest exists - match found", func(t *testing.T) {
 		d := &Driver{}
 
 		image := bundle.InvocationImage{}
-		image.Image = "myreg/myimg"
-		image.Digest = "sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
-
-		multipleRepoDigests := append(repoDigests,
-			"myreg/myimg@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321")
-
-		err := d.validateImageDigest(image, multipleRepoDigests)
-		assert.NotNil(t, err, "expected an error")
-		assert.EqualError(t, err, "image myreg/myimg has more than one repo digest")
-	})
-
-	t.Run("image digest exists - an exact match exists", func(t *testing.T) {
-		d := &Driver{}
-
-		image := bundle.InvocationImage{}
-		image.Image = "myreg/myimg"
+		image.Image = "myreg/mybun@sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
 		image.Digest = "sha256:d366a4665ab44f0648d7a00ae3fae139d55e32f9712c67accd604bb55df9d05a"
 
 		err := d.validateImageDigest(image, repoDigests)
-		assert.NoError(t, err)
+		require.NoError(t, err, "validateImageDigest failed")
 	})
 }


### PR DESCRIPTION
Bundles pushed with cnab-to-oci will have invocation images with more than one repoDigest, which is valid. One is for the original invocation image that was pushed. The other is for the relocated invocation image that is now inside the bundle repository.

https://porter.sh/distribute-bundles/#image-references-after-publishing

We should check all of the repoDigests and if a match is found, then it is valid.

This corrects a bug introduced in #227 that is present in [v0.14.0](https://github.com/cnabio/cnab-go/releases/tag/v0.14.0) where executing a bundle fail because bundles pushed with cnab-to-to-oci always have more than one repoDigest.