### PR TITLE
Write docker output to op writer

### DIFF
--- a/action/operation_configs.go
+++ b/action/operation_configs.go
@@ -25,9 +25,12 @@ func (cfgs OperationConfigs) ApplyConfig(op *driver.Operation) error {
 		}
 	}
 
-	// If out wasn't configured, default it
+	// If outputs weren't configured, default them
 	if op.Out == nil {
 		op.Out = os.Stdout
+	}
+	if op.Err == nil {
+		op.Err = os.Stderr
 	}
 
 	return nil

--- a/action/operation_configs_test.go
+++ b/action/operation_configs_test.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,6 +19,7 @@ func TestOperationConfigs_ApplyConfig(t *testing.T) {
 		err := a.ApplyConfig(op)
 		assert.NoError(t, err, "ApplyConfig should not have returned an error")
 		assert.Equal(t, os.Stdout, op.Out, "write to stdout when output is undefined")
+		assert.Equal(t, os.Stderr, op.Err, "write to stderr when output is undefined")
 	})
 
 	t.Run("all config is persisted", func(t *testing.T) {
@@ -30,7 +32,7 @@ func TestOperationConfigs_ApplyConfig(t *testing.T) {
 				return nil
 			},
 			func(op *driver.Operation) error {
-				op.Out = os.Stdout
+				op.Out = ioutil.Discard
 				return nil
 			},
 		}
@@ -38,7 +40,8 @@ func TestOperationConfigs_ApplyConfig(t *testing.T) {
 		err := a.ApplyConfig(op)
 		require.NoError(t, err, "ApplyConfig should not have returned an error")
 		assert.Contains(t, op.Files, "a", "Changes from the first config function were not persisted")
-		assert.Equal(t, os.Stdout, op.Out, "Changes from the second config function were not persisted")
+		assert.Equal(t, ioutil.Discard, op.Out, "Changes from the second config function were not persisted")
+		assert.Equal(t, os.Stderr, op.Err, "Changes from the second config function were not persisted")
 	})
 
 	t.Run("error is returned immediately", func(t *testing.T) {
@@ -47,7 +50,7 @@ func TestOperationConfigs_ApplyConfig(t *testing.T) {
 				return errors.New("oops")
 			},
 			func(op *driver.Operation) error {
-				op.Out = os.Stdout
+				op.Out = ioutil.Discard
 				return nil
 			},
 		}

--- a/driver/command/command.go
+++ b/driver/command/command.go
@@ -109,7 +109,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 
 		// Errors not handled here as they only prevent output from the driver being shown, errors in the command execution are handled when command is executed
 
-		io.Copy(op.Out, stderr)
+		io.Copy(op.Err, stderr)
 	}()
 
 	if err = cmd.Start(); err != nil {

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	unix_path "path"
 
 	"github.com/docker/cli/cli/command"
@@ -251,8 +250,8 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		return driver.OperationResult{}, fmt.Errorf("unable to retrieve logs: %v", err)
 	}
 	var (
-		stdout io.Writer = os.Stdout
-		stderr io.Writer = os.Stderr
+		stdout = op.Out
+		stderr = op.Err
 	)
 	if d.containerOut != nil {
 		stdout = d.containerOut

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -37,6 +37,8 @@ type Operation struct {
 	Outputs map[string]string `json:"outputs"`
 	// Output stream for log messages from the driver
 	Out io.Writer `json:"-"`
+	// Output stream for error messages from the driver
+	Err io.Writer `json:"-"`
 	// Bundle represents the bundle information for use by the operation
 	Bundle *bundle.Bundle
 }


### PR DESCRIPTION
Instead of writing by default to os.Stdout, the docker driver writes to op.Out and the new field op.Err. The op defaults those values to stdout/stderr, so if you weren't setting them previously the behavior is the same though errors are now sent to stderr instead of all lumped into stdout. But for tools like porter that were collecting the output, this enables them to capture all the output and not have rogue lines printed directly to the screen.

This doesn't remove containerOut/containerErr which Docker is relying upon. It should just change the defaults so that the op writers are used first, and are overridden only when SetContainerOut/Err are used.

Closes #78