### PR TITLE
Fix appending digest to pod image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1
+	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1 // indirect
 	github.com/pivotal/image-relocation v0.0.0-20191111101224-e94aff6df06c


### PR DESCRIPTION
When the image was already fully qualified the kubernetes driver was double appending the digest, e.g. foo/bar@sha:abc123@sha:abc123