### PR TITLE
Support in-cluster k8s

### DIFF
--- a/driver/debug/debug.go
+++ b/driver/debug/debug.go
@@ -42,6 +42,7 @@ func (d *Driver) Config() map[string]string {
 }
 
 // SetConfig sets configuration for this driver
-func (d *Driver) SetConfig(settings map[string]string) {
+func (d *Driver) SetConfig(settings map[string]string) error {
 	d.config = settings
+	return nil
 }

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/registry"
 	"github.com/mitchellh/copystructure"
-
 	"github.com/pkg/errors"
 
 	"github.com/cnabio/cnab-go/bundle"
@@ -98,16 +97,17 @@ func (d *Driver) Config() map[string]string {
 }
 
 // SetConfig sets Docker driver configuration
-func (d *Driver) SetConfig(settings map[string]string) {
+func (d *Driver) SetConfig(settings map[string]string) error {
 	// Set default and provide feedback on acceptable input values.
 	value, ok := settings["CLEANUP_CONTAINERS"]
 	if !ok {
 		settings["CLEANUP_CONTAINERS"] = "true"
 	} else if value != "true" && value != "false" {
-		fmt.Printf("CLEANUP_CONTAINERS environment variable has unexpected value %q. Supported values are 'true', 'false', or unset.", value)
+		return fmt.Errorf("environment variable CLEANUP_CONTAINERS has unexpected value %q. Supported values are 'true', 'false', or unset", value)
 	}
 
 	d.config = settings
+	return nil
 }
 
 // SetDockerCli makes the driver use an already initialized cli

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -87,6 +87,56 @@ func TestDriver_GetConfigurationOptions(t *testing.T) {
 	})
 }
 
+func TestDriver_SetConfig(t *testing.T) {
+	testcases := []struct {
+		name      string
+		settings  map[string]string
+		wantError string
+	}{
+		{
+			name: "valid settings",
+			settings: map[string]string{
+				"VERBOSE": "true",
+			},
+			wantError: "",
+		},
+		{
+			name: "cleanup containers: true",
+			settings: map[string]string{
+				"CLEANUP_CONTAINERS": "true",
+			},
+			wantError: "",
+		},
+		{
+			name: "cleanup containers: false",
+			settings: map[string]string{
+				"CLEANUP_CONTAINERS": "false",
+			},
+			wantError: "",
+		},
+		{
+			name: "cleanup containers - invalid",
+			settings: map[string]string{
+				"CLEANUP_CONTAINERS": "1",
+			},
+			wantError: "environment variable CLEANUP_CONTAINERS has unexpected value",
+		},
+	}
+
+	for _, tc := range testcases {
+		d := Driver{}
+		err := d.SetConfig(tc.settings)
+
+		if tc.wantError == "" {
+			require.NoError(t, err, "expected SetConfig to succeed")
+			assert.Equal(t, tc.settings, d.config, "expected all of the specified settings to be copied")
+		} else {
+			require.Error(t, err, "expected SetConfig to fail")
+			assert.Contains(t, err.Error(), tc.wantError)
+		}
+	}
+}
+
 func TestDriver_ValidateImageDigest(t *testing.T) {
 	// Mimic the digests created when a bundle is pushed with cnab-to-oci
 	// there is one for the original invocation image and another

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -103,5 +103,5 @@ type Configurable interface {
 	Config() map[string]string
 	// SetConfig allows setting configuration, where name corresponds to the key in Config, and value is
 	// the value to be set.
-	SetConfig(map[string]string)
+	SetConfig(map[string]string) error
 }

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -80,7 +80,7 @@ func (k *Driver) Handles(imagetype string) bool {
 // Config returns the Kubernetes driver configuration options.
 func (k *Driver) Config() map[string]string {
 	return map[string]string{
-		"IN_CLUSTER":      "Connect to the ambient cluster",
+		"IN_CLUSTER":      "Connect to the cluster using in-cluster environment variables",
 		"CLEANUP_JOBS":    "If true, the job and associated secrets will be destroyed when it finishes running. If false, it will not be destroyed. The supported values are true and false. Defaults to true.",
 		"KUBE_NAMESPACE":  "Kubernetes namespace in which to run the invocation image",
 		"SERVICE_ACCOUNT": "Kubernetes service account to be mounted by the invocation image (if empty, no service account token will be mounted)",

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -81,6 +81,7 @@ func (k *Driver) Handles(imagetype string) bool {
 func (k *Driver) Config() map[string]string {
 	return map[string]string{
 		"IN_CLUSTER":      "Connect to the ambient cluster",
+		"CLEANUP_JOBS":    "If true, the job and associated secrets will be destroyed when it finishes running. If false, it will not be destroyed. The supported values are true and false. Defaults to true.",
 		"KUBE_NAMESPACE":  "Kubernetes namespace in which to run the invocation image",
 		"SERVICE_ACCOUNT": "Kubernetes service account to be mounted by the invocation image (if empty, no service account token will be mounted)",
 		"KUBECONFIG":      "Absolute path to the kubeconfig file",
@@ -94,8 +95,12 @@ func (k *Driver) SetConfig(settings map[string]string) error {
 	k.Namespace = settings["KUBE_NAMESPACE"]
 	k.ServiceAccountName = settings["SERVICE_ACCOUNT"]
 
+	cleanup, err := strconv.ParseBool(settings["CLEANUP_JOBS"])
+	if err != nil {
+		k.SkipCleanup = !cleanup
+	}
+
 	var conf *rest.Config
-	var err error
 	if incluster, _ := strconv.ParseBool(settings["IN_CLUSTER"]); incluster {
 		conf, err = rest.InClusterConfig()
 		if err != nil {

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/driver"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDriver_Run_Integration(t *testing.T) {
@@ -84,4 +86,15 @@ func TestDriver_Run_Integration(t *testing.T) {
 			assert.Equal(t, tc.output, output.String())
 		})
 	}
+}
+
+func TestDriver_SetConfig(t *testing.T) {
+	t.Run("kubeconfig", func(t *testing.T) {
+
+		d := Driver{}
+		err := d.SetConfig(map[string]string{
+			"KUBECONFIG": os.Getenv("KUBECONFIG"),
+		})
+		require.NoError(t, err)
+	})
 }

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -162,3 +162,16 @@ func TestGenerateNameTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestDriver_SetConfig_Fails(t *testing.T) {
+	t.Run("kubeconfig invalid", func(t *testing.T) {
+
+		d := Driver{}
+		err := d.SetConfig(map[string]string{
+			"KUBECONFIG": "invalid",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error retrieving external kubernetes configuration using configuration")
+	})
+
+}

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -174,4 +174,17 @@ func TestDriver_SetConfig_Fails(t *testing.T) {
 		assert.Contains(t, err.Error(), "error retrieving external kubernetes configuration using configuration")
 	})
 
+	t.Run("use in-cluster outside cluster", func(t *testing.T) {
+		// Force this to fail even when the tests are run inside brigade
+		orig := os.Getenv("KUBERNETES_SERVICE_HOST")
+		os.Unsetenv("KUBERNETES_SERVICE_HOST")
+		defer os.Setenv("KUBERNETES_SERVICE_HOST", orig)
+
+		d := Driver{}
+		err := d.SetConfig(map[string]string{
+			"IN_CLUSTER": "true",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error retrieving in-cluster kubernetes configuration")
+	})
 }


### PR DESCRIPTION
* Add IN_CLUSTER setting to the kubernetes driver.
  The kubernetes driver defaults KUBECONFIG to ~/.kube/config when not set. This prevents the incluster configuration from being used.

  To preserve the existing behavior, I have added IN_CLUSTER which indicates that ambient kubernetes configuration should be used. This is intended for when the cnab process is running inside a pod.
* Do not panic when setting driver config 
  Use the go, Luke. Return errors instead of throwing a panic. This is a breaking change to the driver API, but we aren't at 1.0 and avoiding panics seems worth it.

I didn't see a way to add a test for in-cluster without a ton of extra test infra that we don't have right now. If we are concerned that incluster config needs a test case, we will need to add a docker registry to our kind cluster, build a custom image with a fake cnab-go cli, push it to the kind registry and then run it as a pod. It didn't seem worth it just for this one test. 🤷‍♀️ 