### PR TITLE
K8s driver improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifndef HAS_GOLANGCI
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
 endif
 ifndef HAS_KIND
-	go get sigs.k8s.io/kind@v0.6.0
+	go get sigs.k8s.io/kind@v0.10.0
 endif
 ifndef HAS_KUBECTL
 	echo "Follow instructions at https://kubernetes.io/docs/tasks/tools/install-kubectl/ to install kubectl."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
     set -xeuo pipefail
     go env
     go mod download
-    go get sigs.k8s.io/kind@v0.6.0
+    go get sigs.k8s.io/kind@v0.10.0
     sudo make bootstrap
     make fetch-schemas build lint coverage
     GOOS=windows make build

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -108,7 +108,7 @@ func (k *Driver) SetConfig(settings map[string]string) error {
 	k.JobVolumeName = settings["JOB_VOLUME_NAME"]
 
 	cleanup, err := strconv.ParseBool(settings["CLEANUP_JOBS"])
-	if err != nil {
+	if err == nil {
 		k.SkipCleanup = !cleanup
 	}
 

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -75,7 +75,7 @@ type Driver struct {
 	// Set to zero to not use a limit. Defaults to zero.
 	LimitCPU resource.Quantity
 
-	// LimitMemory is amount of memory to request and the limit for the bundle's job.
+	// LimitMemory is the amount of memory to request and the limit for the bundle's job.
 	// Set to zero to not use a limit. Defaults to zero.
 	LimitMemory resource.Quantity
 
@@ -261,7 +261,7 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 	}
 
 	const sharedVolumeName = "cnab-driver-share"
-	err = k.initJobVolumes(err)
+	err = k.initJobVolumes()
 	if err != nil {
 		return driver.OperationResult{}, err
 	}
@@ -429,11 +429,10 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 	return opResult, opErr.ErrorOrNil()
 }
 
-func (k *Driver) initJobVolumes(err error) error {
-	// Store all job input files in ./inputs and outputs in ./outputs on the shared volume
-
+// Store all job input files in ./inputs and outputs in ./outputs on the shared volume
+func (k *Driver) initJobVolumes() error {
 	inputsDir := filepath.Join(k.JobVolumePath, "inputs")
-	err = os.Mkdir(inputsDir, 0700)
+	err := os.Mkdir(inputsDir, 0700)
 	if err != nil && !os.IsExist(err) {
 		return errors.Wrapf(err, "error creating inputs directory %s on shared job volume %s", inputsDir, k.JobVolumeName)
 	}

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -135,19 +135,12 @@ func createTestPVC(t *testing.T) (string, func()) {
 	}
 }
 
-func TestDriver_SetConfig(t *testing.T) {
-	t.Run("cleanup_jobs", func(t *testing.T) {
-		d := Driver{}
-		d.SetConfig(map[string]string{
-			"CLEANUP_JOBS": "false",
-		})
-		assert.True(t, d.SkipCleanup)
-	})
+func TestDriver_InitClient(t *testing.T) {
 	t.Run("kubeconfig", func(t *testing.T) {
-		d := Driver{}
-		err := d.SetConfig(map[string]string{
-			"KUBECONFIG": os.Getenv("KUBECONFIG"),
-		})
+		d := Driver{
+			Kubeconfig: os.Getenv("KUBECONFIG"),
+		}
+		err := d.initClient()
 		require.NoError(t, err)
 	})
 }

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -4,11 +4,17 @@ package kubernetes
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/driver"
@@ -16,10 +22,6 @@ import (
 
 func TestDriver_Run_Integration(t *testing.T) {
 	k := &Driver{}
-	k.SetConfig(map[string]string{
-		"KUBE_NAMESPACE": "default",
-		"KUBECONFIG":     os.Getenv("KUBECONFIG"),
-	})
 	k.ActiveDeadlineSeconds = 60
 
 	cases := []struct {
@@ -33,6 +35,7 @@ func TestDriver_Run_Integration(t *testing.T) {
 			op: &driver.Operation{
 				Installation: "example",
 				Action:       "install",
+				Bundle:       &bundle.Bundle{},
 				Image: bundle.InvocationImage{
 					BaseImage: bundle.BaseImage{
 						Image:  "cnab/helloworld",
@@ -51,6 +54,7 @@ func TestDriver_Run_Integration(t *testing.T) {
 			op: &driver.Operation{
 				Installation: "greater-than-300-length-and-special-chars/-*()+%@qcUYSfR9MS3BqR0kRDHe2K5EHJa8BJGrcoiDVvsDpATjIkrk4PWrdysIqFpJzrKHauRWfBjjF889Qdc5DUBQ6gKy8Qezkl9HyCmo88hMrkaeVPxknFt0nWRm0xqYhoaY0Db7ZcljchbBAufVvH5l0T7iBdg1E0iSCTZw0v5rCAEclNwzjpg7DfLq2SBdJ0W8XdyQSWVMpakjraXP9droq8ol70gX0QuqAZDkGtHyxet8Akv9lGCCVVFuY4kBdkW3LDHoxl0xz2EZzXja1GTlYui0Bpx0TGqMLish9tBOhuC7",
 				Action:       "install",
+				Bundle:       &bundle.Bundle{},
 				Image: bundle.InvocationImage{
 					BaseImage: bundle.BaseImage{
 						Image:  "cnab/helloworld",
@@ -76,7 +80,24 @@ func TestDriver_Run_Integration(t *testing.T) {
 			tc.op.Environment["CNAB_ACTION"] = tc.op.Action
 			tc.op.Environment["CNAB_INSTALLATION_NAME"] = tc.op.Installation
 
-			_, err := k.Run(tc.op)
+			// Create a volume to share data with the invocation image
+			pvc, cleanup := createTestPVC(t)
+			defer cleanup()
+
+			// Simulate mounting the shared volume
+			sharedDir, err := ioutil.TempDir("", "cnab-go")
+			require.NoError(t, err, "could not create test directory")
+			defer os.RemoveAll(sharedDir)
+
+			err = k.SetConfig(map[string]string{
+				SettingJobVolumePath: sharedDir,
+				SettingJobVolumeName: pvc,
+				SettingKubeNamespace: "default",
+				SettingKubeconfig:    os.Getenv("KUBECONFIG"),
+			})
+			require.NoError(t, err, "SetConfig failed")
+
+			_, err = k.Run(tc.op)
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())
@@ -85,6 +106,32 @@ func TestDriver_Run_Integration(t *testing.T) {
 			}
 			assert.Equal(t, tc.output, output.String())
 		})
+	}
+}
+
+func createTestPVC(t *testing.T) (string, func()) {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cnab-driver-shared",
+			Namespace:    "default",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.ResourceRequirements{Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceStorage: resource.MustParse("64Mi"),
+			}},
+		},
+	}
+	kubeconfig := os.Getenv("KUBECONFIG")
+	conf, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	require.NoError(t, err, "BuildConfigFromFlags failed")
+	coreClient, err := coreclientv1.NewForConfig(conf)
+	pvcClient := coreClient.PersistentVolumeClaims("default")
+	pvc, err = pvcClient.Create(pvc)
+	require.NoError(t, err, "create pvc failed")
+
+	return pvc.Name, func() {
+		pvcClient.Delete(pvc.Name, &metav1.DeleteOptions{})
 	}
 }
 

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -89,8 +89,14 @@ func TestDriver_Run_Integration(t *testing.T) {
 }
 
 func TestDriver_SetConfig(t *testing.T) {
+	t.Run("cleanup_jobs", func(t *testing.T) {
+		d := Driver{}
+		d.SetConfig(map[string]string{
+			"CLEANUP_JOBS": "false",
+		})
+		assert.True(t, d.SkipCleanup)
+	})
 	t.Run("kubeconfig", func(t *testing.T) {
-
 		d := Driver{}
 		err := d.SetConfig(map[string]string{
 			"KUBECONFIG": os.Getenv("KUBECONFIG"),

--- a/e2e-kind.sh
+++ b/e2e-kind.sh
@@ -9,7 +9,7 @@ set -o pipefail
 CLUSTER_NAME=cnab-go-testing
 readonly CLUSTER_NAME
 
-K8S_VERSION=v1.15.3
+K8S_VERSION=v1.19.1
 readonly K8S_VERSION
 
 KIND_KUBECONFIG="$PWD/kind-kubeconfig.yaml"


### PR DESCRIPTION
I am working on a Porter Operator that can run CNAB bundles using K8s CRDs. As part of that I had to make some changes to the Kubernetes driver to get real (not sample) bundles to work.

* Mount a persistent volume to share data: injected files and outputs, between the driver and the bundle job.
* Apply custom labels in the kubernetes driver
  Allow the caller to specify additional labels to apply to resources created by the driver.
* Fix setting CLEANUP_JOBS
  I had the if statement inverted... I've added a test to make sure it (and other settings) are correct.
* Remove requiredCompletions from k8s driver
  The only value that ever makes sense for requiredCompletions is 1 because we aren't running parallel pods for the bundle job.
*  Improve defaulting for kubernetes driver
    * When LimitCPU or LimitMemory is 0, do not set a limit. We don't set a request size, and requesting 0 is not the same as not having a requested resource quantity. This can lead to increased pod evictions.
    * Clarify that LimitCPU and LimitMemory are also used for the requested resources.
    * When ActiveDeadlineSeconds is 0, do not set a deadline.
    * Split reading the configuration in SetConfig and attempting to connect to the cluster, so that we can unit test the settings logic.
    * Move validation for KUBE_NAMESPACE into SetConfig so that any errors can be reported immediately.
    * Add comments for all of the driver settings

With these changes I am able to run @squillace 's kubeflow bundle! 🎉 

```yaml
apiVersion: porter.sh/v1
kind: Installation
metadata:
  name: kubeflow
spec:
  reference: "ghcr.io/squillace/aks-kubeflow-msi:v0.1.7"
  action: "install"
  credentialSets:
    - aks
```

Closes #73