### PR TITLE
Rename master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,10 @@ When you are asked to cut a new release, here is the process:
    [Release naming scheme][release-name] explains the meaning behind the
    release names.
 
-1. Ensure that the master CI build is passing, then make the tag and push it.
+1. Ensure that the CI build is passing, then make the tag and push it.
 
    ```
-   git checkout master
+   git checkout main
    git pull
    git tag VERSION -a -m ""
    git push --tags

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cnab-go
 
-[![Build Status](https://dev.azure.com/deislabs/cnab-go/_apis/build/status/cnab-go?branchName=master)](https://dev.azure.com/deislabs/cnab-go/_build/latest?definitionId=27&branchName=master) ![Azure Pipelines coverage](https://img.shields.io/azure-devops/coverage/deislabs/cnab-go/27/master?logo=Azure%20Pipelines)
+[![Build Status](https://dev.azure.com/deislabs/cnab-go/_apis/build/status/cnab-go?branchName=main)](https://dev.azure.com/deislabs/cnab-go/_build/latest?definitionId=27&branchName=main) ![Azure Pipelines coverage](https://img.shields.io/azure-devops/coverage/deislabs/cnab-go/27/main?logo=Azure%20Pipelines)
 
 cnab-go is a library for building [CNAB](https://github.com/cnabio/cnab-spec) clients. It provides the building blocks relevant to the CNAB specification so that you may build tooling without needing to implement all aspects of the CNAB specification.
 


### PR DESCRIPTION
I am renaming the default branch now, but this fixes our documentation to match.