### PR TITLE
Log an error when kubernetes driver cannot stream logs

### DIFF
--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -351,6 +351,7 @@ func (k *Driver) streamPodLogs(options metav1.ListOptions, out io.Writer, done c
 				if err != nil {
 					// There was an error connecting to the pod, so continue the loop and attempt streaming
 					// the logs again.
+					fmt.Fprintln(out, errors.Wrapf(err, "Could not stream logs for pod %s. Retrying...", podName))
 					continue
 				}
 
@@ -358,6 +359,7 @@ func (k *Driver) streamPodLogs(options metav1.ListOptions, out io.Writer, done c
 				bytesRead, err := io.Copy(out, reader)
 				reader.Close()
 				if err != nil {
+					fmt.Fprintln(out, errors.Wrapf(err, "Could not copy logs for pod %s. Retrying...", podName))
 					continue
 				}
 				if bytesRead == 0 {

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -83,7 +83,7 @@ func TestDriver_Run_Integration(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tc.output, output.String())
+			assert.Contains(t, output.String(), tc.output)
 		})
 	}
 }


### PR DESCRIPTION
Currently we are silently ignoring errors when we cannot stream the pod logs. Which makes it super hard to troubleshoot why it didn't work, usually RBAC because you don't have get+list for pods/log. This prints a message in the logs indicating there was a problem and allows the job to finish.