### PR TITLE
Check credential.ApplyTo setting credentials on the operation

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -366,7 +366,7 @@ func getImageMap(b bundle.Bundle) ([]byte, error) {
 }
 
 func opFromClaim(stateless bool, c claim.Claim, ii bundle.InvocationImage, creds valuesource.Set) (*driver.Operation, error) {
-	env, files, err := expandCredentials(c.Bundle, creds, stateless)
+	env, files, err := expandCredentials(c.Bundle, creds, stateless, c.Action)
 	if err != nil {
 		return nil, err
 	}
@@ -478,12 +478,12 @@ func injectParameters(c claim.Claim, env, files map[string]string) error {
 //
 // This matches the credentials required by the bundle to the credentials present
 // in the Set, and then expands them per the definition in the Bundle.
-func expandCredentials(b bundle.Bundle, set valuesource.Set, stateless bool) (env, files map[string]string, err error) {
+func expandCredentials(b bundle.Bundle, set valuesource.Set, stateless bool, action string) (env, files map[string]string, err error) {
 	env, files = map[string]string{}, map[string]string{}
 	for name, val := range b.Credentials {
 		src, ok := set[name]
 		if !ok {
-			if stateless || !val.Required {
+			if stateless || !val.Required || !val.AppliesTo(action) {
 				continue
 			}
 			err = fmt.Errorf("credential %q is missing from the user-supplied credentials", name)

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -1080,7 +1080,7 @@ func TestExpandCredentials(t *testing.T) {
 			"third":  "third",
 		}
 
-		env, path, err := expandCredentials(b, set, false)
+		env, path, err := expandCredentials(b, set, false, "install")
 		is := assert.New(t)
 		is.NoError(err)
 		for k, v := range b.Credentials {
@@ -1106,9 +1106,9 @@ func TestExpandCredentials(t *testing.T) {
 			},
 		}
 		set := valuesource.Set{}
-		_, _, err := expandCredentials(b, set, false)
+		_, _, err := expandCredentials(b, set, false, "install")
 		assert.EqualError(t, err, `credential "first" is missing from the user-supplied credentials`)
-		_, _, err = expandCredentials(b, set, true)
+		_, _, err = expandCredentials(b, set, true, "install")
 		assert.NoError(t, err)
 	})
 
@@ -1124,9 +1124,29 @@ func TestExpandCredentials(t *testing.T) {
 			},
 		}
 		set := valuesource.Set{}
-		_, _, err := expandCredentials(b, set, false)
+		_, _, err := expandCredentials(b, set, false, "install")
 		assert.NoError(t, err)
-		_, _, err = expandCredentials(b, set, true)
+		_, _, err = expandCredentials(b, set, true, "install")
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing cred with ApplyTo", func(t *testing.T) {
+		b := bundle.Bundle{
+			Name: "knapsack",
+			Credentials: map[string]bundle.Credential{
+				"first": {
+					Location: bundle.Location{
+						EnvironmentVariable: "FIRST_VAR",
+					},
+					Required: true,
+					ApplyTo:  []string{"install"},
+				},
+			},
+		}
+		set := valuesource.Set{}
+		_, _, err := expandCredentials(b, set, false, "install")
+		assert.EqualError(t, err, `credential "first" is missing from the user-supplied credentials`)
+		_, _, err = expandCredentials(b, set, false, "upgrade")
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
When we go through the credentials and set them on the operation,
creating either environment variables or paths, take into account
credential.ApplyTo and do not error out when the credential is
required but doesn't apply to the current action.

This builds on top of my previous PR that added support for
credentials to use ApplyTo, where I had missed that we have duplicate
logic for validating credentials depending on the context (populating
the operation vs validating a credential set).