### PR TITLE
Adds Pod Affinity to Kubernetes driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/
 __pycache__/
 /duffle
 .vscode/settings.json
+.vscode/tasks.json
 
 # Test Output
 kind-kubeconfig.yaml

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ test:
 lint:
 	golangci-lint run --config ./golangci.yml
 
+.PHONY: create-test-cluster
+create-test-cluster:
+	./e2e-kind.sh create_kind_cluster
+
+.PHONY: delete-test-cluster
+delete-test-cluster:
+	./e2e-kind.sh delete_kind_cluster
+
 HAS_GOLANGCI := $(shell $(CHECK) golangci-lint)
 GOLANGCI_VERSION := v1.21.0
 HAS_KIND := $(shell $(CHECK) kind)
@@ -62,7 +70,7 @@ endif
 
 .PHONY: coverage
 coverage: compile-integration-tests
-	./e2e-kind.sh
+	./e2e-kind.sh main
 
 .PHONY: compile-integration-tests
 compile-integration-tests:

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -302,15 +302,16 @@ func TestDriver_ConfigureJob(t *testing.T) {
 func TestDriver_SetConfig(t *testing.T) {
 	validSettings := func() map[string]string {
 		return map[string]string{
-			SettingInCluster:      "true",
-			SettingKubeconfig:     "/tmp/kube.config",
-			SettingMasterURL:      "http://example.com",
-			SettingKubeNamespace:  "default",
-			SettingJobVolumeName:  "cnab-driver-shared",
-			SettingJobVolumePath:  "/tmp",
-			SettingCleanupJobs:    "false",
-			SettingLabels:         "a=1 b=2",
-			SettingServiceAccount: "myacct",
+			SettingInCluster:              "true",
+			SettingKubeconfig:             "/tmp/kube.config",
+			SettingMasterURL:              "http://example.com",
+			SettingKubeNamespace:          "default",
+			SettingJobVolumeName:          "cnab-driver-shared",
+			SettingJobVolumePath:          "/tmp",
+			SettingCleanupJobs:            "false",
+			SettingLabels:                 "a=1 b=2",
+			SettingServiceAccount:         "myacct",
+			SettingPodAffinityMatchLabels: "a=b x=y",
 		}
 	}
 
@@ -381,5 +382,23 @@ func TestDriver_SetConfig(t *testing.T) {
 		err := d.SetConfig(settings)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "setting JOB_VOLUME_PATH is required")
+	})
+
+	t.Run("invalid PodAffinity match labels ", func(t *testing.T) {
+		d := Driver{}
+		settings := validSettings()
+		settings[SettingPodAffinityMatchLabels] = "AB"
+		err := d.SetConfig(settings)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AFFINITY_MATCH_LABELS is incorrectly formattted each value should be in the form X=Y, got")
+	})
+
+	t.Run("job volume path missing", func(t *testing.T) {
+		d := Driver{}
+		settings := validSettings()
+		settings[SettingPodAffinityMatchLabels] = "A=B%C"
+		err := d.SetConfig(settings)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character")
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
 	k8s.io/client-go v0.0.0-20191016111102-bec269661e48
+	k8s.io/kubernetes v1.11.10
 	vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -651,6 +651,7 @@ k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apimachinery v0.0.0-20190806215851-162a2dabc72f/go.mod h1:+ntn62igV2hyNj7/0brOvXSMONE2KxcePkSxK7/9FFQ=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8 h1:Iieh/ZEgT3BWwbLD5qEKcY06jKuPEl6zC7gPSehoLw4=
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
+k8s.io/apimachinery v0.20.5 h1:wO/FxMVRn223rAKxnBbwCyuN96bS9MFTIvP0e/V7cps=
 k8s.io/client-go v0.0.0-20180910083459-2cefa64ff137/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48 h1:C2XVy2z0dV94q9hSSoCuTPp1KOG7IegvbdXuz9VGxoU=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3dMaFyyvHVi/aLarVHpbs8bgCU=

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,7 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kubernetes v1.11.10 h1:wCo67+wmguioiYv0ipIiTaXbVPfFBBjOTgIngeGGG+A=
 k8s.io/kubernetes v1.11.10/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/kind.config.yaml
+++ b/kind.config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
This change introduces a setting to specify labels to be used for affinity for the Kubernetes driver.

The driver uses a PVC to copy input and output data between the driver and the job that runs the invocation image, In some cases there is a need to make sure that the job runs on the same node as another pod. For example, where the PVC is bound to the node running the driver with ReadWriteOnce access mode then the job running the invocation image must run on the same node as the pod creating the PVC, this change enables a client to set pod affinity appropriately.

To specify affinity with a pod the client should set the environment variable `AFFINITY_MATCH_LABELS`  with label name value pairs separated by whitespace. (e.g 'A=B X=Y'). These labels are used to set Pod Affinity constraints for the job running the invocation image.

Signed-off-by: Simon Davies <simongdavies@users.noreply.github.com>