### PR TITLE
Remove unnecessary validation of docker tag on Invocation Images

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -139,7 +139,7 @@ func (img *InvocationImage) DeepCopy() *InvocationImage {
 func (img InvocationImage) Validate() error {
 	switch img.ImageType {
 	case "docker", "oci":
-		return validateDockerish(img.Image)
+		return nil
 	default:
 		return nil
 	}
@@ -278,12 +278,5 @@ func (b Bundle) Validate() error {
 		}
 	}
 
-	return nil
-}
-
-func validateDockerish(s string) error {
-	if !strings.Contains(s, ":") {
-		return errors.New("tag is required")
-	}
 	return nil
 }


### PR DESCRIPTION
Our image tagging system includes SCM and CI metadata, which changes frequently, which causes an excess of `bundle.json`s to be created. To prevent this, we wanted to omit the tag to keep the `bundle.json` less volatile. 

However, there seems to be a validation, just on Invocation Images, to ensure that the tag is present. This validation seems to have come from a prototype implementation of `duffle`, but I can't find any comments or tests explaining why it's there [1].

As far as I can tell from the spec, omitting a tag is acceptable and is even present in some of the examples for the dependent images [2]. Additionally, pulling by digest is supported by both Docker [3] and the distribution spec [4].

Happy to make an issue if further discussion is warranted, this change seemed like a no-brainer, but happy to comply with your contributions process [5].

[1] https://github.com/cnabio/cnab-go/commit/aa1d2a6e7dd6481db92fc8f5777a58657c0c93e3
[2] https://github.com/cnabio/cnab-spec/blob/cnab-core-1.1.0/101-bundle-json.md#the-image-map
[3] https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier
[4] https://github.com/opencontainers/distribution-spec/blob/v1.0.0-rc2/spec.md#pulling-manifests
[5] https://github.com/cnabio/cnab-go/blob/main/CONTRIBUTING.md