### PR TITLE
feat(schema.go): add support for params of object type in ConvertValue

### DIFF
--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -131,6 +131,12 @@ func (s *Schema) ConvertValue(val string) (interface{}, error) {
 		default:
 			return false, errors.Errorf("%q is not a valid boolean", val)
 		}
+	case "object":
+		var obj interface{}
+		if err := json.Unmarshal([]byte(val), &obj); err != nil {
+			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json object", val)
+		}
+		return obj, nil
 	default:
 		return nil, errors.New("invalid definition")
 	}

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -335,16 +335,12 @@ func TestConvertValue(t *testing.T) {
 	is.Error(err)
 
 	pd.Type = "object"
-	_, err = pd.ConvertValue("nope")
-	is.Error(err)
+	out, err = pd.ConvertValue(`{"object": true}`)
+	is.NoError(err)
+	is.Equal(map[string]interface{}{"object": true}, out)
 
-	_, err = pd.ConvertValue("123")
+	out, err = pd.ConvertValue(`{"object" true}`)
 	is.Error(err)
-
-	_, err = pd.ConvertValue("true")
-	is.Error(err)
-
-	_, err = pd.ConvertValue("123.5")
-	is.Error(err)
-
+	is.Contains(err.Error(), "could not unmarshal")
+	is.Equal(nil, out)
 }


### PR DESCRIPTION
* Adds support for params of type `object` in ConvertValue

(Original issue from Porter: https://github.com/getporter/porter/issues/1459)