### PR TITLE
fix(bundle.go): validate param regardless of if override or default

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -200,24 +200,30 @@ func ValuesOrDefaults(vals map[string]interface{}, b *Bundle, action string) (ma
 		if !ok {
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
+
+		// Set to the corresponding val if it exists in the supplied overrides,
+		// else error out if required or set to the default defined on the parameter
+		var uncoerced interface{}
 		if val, ok := vals[name]; ok {
-			valErrs, err := s.Validate(val)
-			if err != nil {
-				return res, pkgErrors.Wrapf(err, "encountered an error validating parameter %s", name)
-			}
-			// This interface returns a single error. Validation can have multiple errors. For now return the first
-			// We should update this later.
-			if len(valErrs) > 0 {
-				valErr := valErrs[0]
-				return res, fmt.Errorf("cannot use value: %v as parameter %s: %s ", val, name, valErr.Error)
-			}
-			typedVal := s.CoerceValue(val)
-			res[name] = typedVal
-			continue
+			uncoerced = val
 		} else if param.Required {
 			return res, fmt.Errorf("parameter %q is required", name)
+		} else {
+			uncoerced = s.Default
 		}
-		res[name] = s.Default
+
+		// Validate the selection
+		valErrs, err := s.Validate(uncoerced)
+		if err != nil {
+			return res, pkgErrors.Wrapf(err, "encountered an error validating parameter %s", name)
+		}
+		// This interface returns a single error. Validation can have multiple errors. For now return the first
+		// We should update this later.
+		if len(valErrs) > 0 {
+			valErr := valErrs[0]
+			return res, fmt.Errorf("cannot use value: %v as parameter %s: %s", uncoerced, name, valErr.Error)
+		}
+		res[name] = s.CoerceValue(uncoerced)
 	}
 	return res, nil
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -271,6 +271,29 @@ func TestValuesOrDefaults_NotApplicableToAction(t *testing.T) {
 	require.Equal(t, expected, res)
 }
 
+func TestValuesOrDefaults_DefaultFailsValidation(t *testing.T) {
+	is := assert.New(t)
+
+	b := &Bundle{
+		Definitions: map[string]*definition.Schema{
+			"param": {
+				Type:    "boolean",
+				Default: "notaboolean",
+			},
+		},
+		Parameters: map[string]Parameter{
+			"param": {
+				Definition: "param",
+			},
+		},
+	}
+
+	_, err := ValuesOrDefaults(map[string]interface{}{}, b, "install")
+	is.Error(err)
+	is.Contains(err.Error(), "cannot use value")
+	is.Contains(err.Error(), "type should be boolean")
+}
+
 func TestValidateVersionTag(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
* Fixes a bug wherein we weren't previously validating a parameter if we inherit the default.  Now we validate regardless of where we inherit the parameter from (e.g. an override or a default).