### PR TITLE
feat(schema.go): add support for params of type array

### DIFF
--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -131,10 +131,16 @@ func (s *Schema) ConvertValue(val string) (interface{}, error) {
 		default:
 			return false, errors.Errorf("%q is not a valid boolean", val)
 		}
-	case "array", "object":
-		var obj interface{}
+	case "array":
+		var obj []interface{}
 		if err := json.Unmarshal([]byte(val), &obj); err != nil {
-			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json %s", val, dataType)
+			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json array", val)
+		}
+		return obj, nil
+	case "object":
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(val), &obj); err != nil {
+			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json object", val)
 		}
 		return obj, nil
 	default:

--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -131,10 +131,10 @@ func (s *Schema) ConvertValue(val string) (interface{}, error) {
 		default:
 			return false, errors.Errorf("%q is not a valid boolean", val)
 		}
-	case "object":
+	case "array", "object":
 		var obj interface{}
 		if err := json.Unmarshal([]byte(val), &obj); err != nil {
-			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json object", val)
+			return nil, errors.Wrapf(err, "could not unmarshal value %v into a json %s", val, dataType)
 		}
 		return obj, nil
 	default:

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -322,17 +322,15 @@ func TestConvertValue(t *testing.T) {
 	is.Error(err)
 
 	pd.Type = "array"
-	_, err = pd.ConvertValue("nope")
-	is.Error(err)
+	out, err = pd.ConvertValue(`["chocolate", "chip", "cookies"]`)
+	is.NoError(err)
+	is.Equal([]interface{}{"chocolate", "chip", "cookies"}, out)
 
-	_, err = pd.ConvertValue("123")
+	out, err = pd.ConvertValue(`["chocolate" "chip" "cookies"]`)
 	is.Error(err)
-
-	_, err = pd.ConvertValue("true")
-	is.Error(err)
-
-	_, err = pd.ConvertValue("123.5")
-	is.Error(err)
+	is.Contains(err.Error(), "could not unmarshal")
+	is.Contains(err.Error(), "into a json array")
+	is.Equal(nil, out)
 
 	pd.Type = "object"
 	out, err = pd.ConvertValue(`{"object": true}`)
@@ -342,5 +340,6 @@ func TestConvertValue(t *testing.T) {
 	out, err = pd.ConvertValue(`{"object" true}`)
 	is.Error(err)
 	is.Contains(err.Error(), "could not unmarshal")
+	is.Contains(err.Error(), "into a json object")
 	is.Equal(nil, out)
 }

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -322,9 +322,11 @@ func TestConvertValue(t *testing.T) {
 	is.Error(err)
 
 	pd.Type = "array"
-	out, err = pd.ConvertValue(`["chocolate", "chip", "cookies"]`)
-	is.NoError(err)
-	is.Equal([]interface{}{"chocolate", "chip", "cookies"}, out)
+	out, err = pd.ConvertValue(`"cookies"`)
+	is.Error(err)
+	is.Contains(err.Error(), "could not unmarshal")
+	is.Contains(err.Error(), "into a json array")
+	is.Equal(nil, out)
 
 	out, err = pd.ConvertValue(`["chocolate" "chip" "cookies"]`)
 	is.Error(err)
@@ -332,14 +334,30 @@ func TestConvertValue(t *testing.T) {
 	is.Contains(err.Error(), "into a json array")
 	is.Equal(nil, out)
 
-	pd.Type = "object"
-	out, err = pd.ConvertValue(`{"object": true}`)
+	out, err = pd.ConvertValue(`["chocolate", "chip", "cookies"]`)
 	is.NoError(err)
-	is.Equal(map[string]interface{}{"object": true}, out)
+	is.Equal([]interface{}{"chocolate", "chip", "cookies"}, out)
+
+	pd.Type = "object"
+	out, err = pd.ConvertValue(`"object"`)
+	is.Error(err)
+	is.Contains(err.Error(), "could not unmarshal")
+	is.Contains(err.Error(), "into a json object")
+	is.Equal(nil, out)
+
+	out, err = pd.ConvertValue(`"object": true`)
+	is.Error(err)
+	is.Contains(err.Error(), "could not unmarshal")
+	is.Contains(err.Error(), "into a json object")
+	is.Equal(nil, out)
 
 	out, err = pd.ConvertValue(`{"object" true}`)
 	is.Error(err)
 	is.Contains(err.Error(), "could not unmarshal")
 	is.Contains(err.Error(), "into a json object")
 	is.Equal(nil, out)
+
+	out, err = pd.ConvertValue(`{"object": true}`)
+	is.NoError(err)
+	is.Equal(map[string]interface{}{"object": true}, out)
 }


### PR DESCRIPTION
* Adds support for params of type array in the `ConvertValue` function

Builds on/depends on https://github.com/cnabio/cnab-go/pull/251