### PR TITLE
feat(*): validate parameter default against its definition

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -263,7 +263,7 @@ func (b Bundle) Validate() error {
 
 	// Validate the parameters
 	for name, param := range b.Parameters {
-		err := param.Validate()
+		err := param.Validate(name, b)
 		if err != nil {
 			return pkgErrors.Wrapf(err, "validation failed for parameter %q", name)
 		}

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -398,6 +398,9 @@ func TestValidateParameters(t *testing.T) {
 		Version:          "0.1.0",
 		SchemaVersion:    "99.98",
 		InvocationImages: []InvocationImage{img},
+		Definitions: definition.Definitions{
+			"param": &definition.Schema{},
+		},
 	}
 
 	t.Run("bad parameter fails", func(t *testing.T) {

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -45,9 +45,9 @@ func (p *Parameter) Validate(name string, bun Bundle) error {
 			valResult = multierror.Append(valResult, errors.Wrapf(err, "encountered an error validating parameter %s", name))
 		}
 		for _, valErr := range valErrs {
-			valResult = multierror.Append(valResult, fmt.Errorf("cannot use value: %+v for parameter %q: %v", schema.Default, name, valErr.Error))
+			valResult = multierror.Append(valResult, fmt.Errorf("encountered an error validating the default value %v for parameter %q: %v", schema.Default, name, valErr.Error))
 		}
-		if valResult != nil {
+		if valResult.ErrorOrNil() != nil {
 			return valResult
 		}
 	}

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -45,7 +45,7 @@ func (p *Parameter) Validate(name string, bun Bundle) error {
 			valResult = multierror.Append(valResult, errors.Wrapf(err, "encountered an error validating parameter %s", name))
 		}
 		for _, valErr := range valErrs {
-			valResult = multierror.Append(valResult, fmt.Errorf("encountered validation error for parameter %s: %v", name, valErr.Error))
+			valResult = multierror.Append(valResult, fmt.Errorf("cannot use value: %+v for parameter %q: %v", schema.Default, name, valErr.Error))
 		}
 		if valResult != nil {
 			return valResult

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/bundle/definition"
 )
 
 func TestCanReadParameterNames(t *testing.T) {

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -115,7 +115,7 @@ func TestParameterValidate(t *testing.T) {
 		b.Definitions["param-definition"].Default = 1
 		err := p.Validate("param", b)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "encountered validation error for parameter param: type should be string")
+		assert.Contains(t, err.Error(), `cannot use value: 1 for parameter "param": type should be string`)
 	})
 
 	t.Run("successful validation", func(t *testing.T) {

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -115,7 +115,7 @@ func TestParameterValidate(t *testing.T) {
 		b.Definitions["param-definition"].Default = 1
 		err := p.Validate("param", b)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), `cannot use value: 1 for parameter "param": type should be string`)
+		assert.Contains(t, err.Error(), `encountered an error validating the default value 1 for parameter "param": type should be string`)
 	})
 
 	t.Run("successful validation", func(t *testing.T) {


### PR DESCRIPTION
* Adds validation against default parameter values when defined

This can be used to catch validation errors at build-time, rather than runtime (which https://github.com/cnabio/cnab-go/pull/252 adds)