### PR TITLE
feat(outputs.go): add output validation

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -278,6 +278,14 @@ func (b Bundle) Validate() error {
 		}
 	}
 
+	// Validate the outputs
+	for name, output := range b.Outputs {
+		err := output.Validate(name, b)
+		if err != nil {
+			return pkgErrors.Wrapf(err, "validation failed for output %q", name)
+		}
+	}
+
 	return nil
 }
 

--- a/bundle/outputs_test.go
+++ b/bundle/outputs_test.go
@@ -1,0 +1,40 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cnabio/cnab-go/bundle/definition"
+)
+
+func TestOutputValidate(t *testing.T) {
+	b := Bundle{
+		Definitions: map[string]*definition.Schema{
+			"output-definition": {
+				Type: "string",
+			},
+		},
+	}
+	o := Output{}
+
+	t.Run("empty output fails", func(t *testing.T) {
+		err := o.Validate("output", b)
+		assert.EqualError(t, err, "output definition must be provided")
+	})
+
+	t.Run("unsuccessful validation", func(t *testing.T) {
+		o.Definition = "output-definition"
+		b.Definitions["output-definition"].Default = 1
+		err := o.Validate("output", b)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), `encountered an error validating the default value 1 for output "output": type should be string`)
+	})
+
+	t.Run("successful validation", func(t *testing.T) {
+		o.Definition = "output-definition"
+		b.Definitions["output-definition"].Default = "foo"
+		err := o.Validate("output", b)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
* Adds validation of a bundle's outputs, including validating that the default value (if provided) adheres to the output schema