### PR TITLE
TrimPrefix and TrimLeft are NOT the same

### DIFF
--- a/claim/claimstore.go
+++ b/claim/claimstore.go
@@ -129,7 +129,7 @@ func (s Store) ListOutputs(resultID string) ([]string, error) {
 	// outputs are keyed with the result, like RESULTID-OUTPUTNAME to make them unique
 	// Strip off RESULTID- and return just OUTPUTNAME
 	for i, fullName := range outputNames {
-		outputNames[i] = strings.TrimLeft(fullName, resultID+"-")
+		outputNames[i] = strings.TrimPrefix(fullName, resultID+"-")
 	}
 	sort.Strings(outputNames)
 	return outputNames, nil


### PR DESCRIPTION
I accidentally used TrimLeft instead of TrimPrefix when reading outputs from the claimstore. TrimLeft removes every character found in a string(cutset) from a string until it hits one that isn't found. TrimPrefix removes the specified string from the beginning of a string.

This can cause a bug where if any character found in the result id (a ulid) is the first character of the output's name, e.g. the result id has a 0 in it and the output name starts with 0, then extra characters from the output name are incorrectly trimmed as well, resulting in being unable to read that output back from the claimstore. 🤦‍♀️ 