### PR TITLE
Do not validate unspecified optional paramters

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -128,6 +128,11 @@ func TestValuesOrDefaults(t *testing.T) {
 				Type:    "boolean",
 				Default: false,
 			},
+			"msg": {
+				Type: "string",
+				// msg has no default, but it is optional
+				// Make sure that we are not validating optional unspecified parameters
+			},
 		},
 		Parameters: map[string]Parameter{
 			"port": {
@@ -142,6 +147,9 @@ func TestValuesOrDefaults(t *testing.T) {
 			"replicaCount": {
 				Definition: "replicaCountType",
 			},
+			"msg": {
+				Definition: "msg",
+			},
 		},
 	}
 
@@ -152,6 +160,7 @@ func TestValuesOrDefaults(t *testing.T) {
 	is.Equal(vod["host"].(string), "localhost")
 	is.Equal(vod["port"].(int), 8080)
 	is.Equal(vod["replicaCount"].(int), 3)
+	is.Equal(nil, vod["msg"], "msg", "msg should be passed even though it had no default and wasn't set because the spec requires it")
 
 	// This should err out because of type problem
 	vals["replicaCount"] = "banana"


### PR DESCRIPTION
This corrects a bug found in v0.20.0 where an optional parameter with no default set causes a validation error when the user does not specify the parameter. The error was:

```
invalid parameters: cannot use value: <nil> as parameter myparm: type should be string, got null
```