### PR TITLE
Remove unused docker driver config options

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -94,10 +94,8 @@ func (d *Driver) GetContainerHostConfig() (container.HostConfig, error) {
 // Config returns the Docker driver configuration options
 func (d *Driver) Config() map[string]string {
 	return map[string]string{
-		"VERBOSE":             "Increase verbosity. true, false are supported values",
 		"PULL_ALWAYS":         "Always pull image, even if locally available (0|1)",
 		"DOCKER_DRIVER_QUIET": "Make the Docker driver quiet (only print container stdout/stderr)",
-		"OUTPUTS_MOUNT_PATH":  "Absolute path to where Docker driver can create temporary directories to bundle outputs. Defaults to temp dir.",
 		"CLEANUP_CONTAINERS":  "If true, the docker container will be destroyed when it finishes running. If false, it will not be destroyed. The supported values are true and false. Defaults to true.",
 		SettingNetwork:        "Attach the invocation image to the specified docker network",
 	}

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -136,7 +136,7 @@ func TestDriver_SetConfig(t *testing.T) {
 		{
 			name: "valid settings",
 			settings: map[string]string{
-				"VERBOSE": "true",
+				"DOCKER_DRIVER_QUIET": "1",
 			},
 			wantError: "",
 		},


### PR DESCRIPTION
Remove unused `VERBOSE` and `OUTPUTS_MOUNT_PATH` docker driver config options.

Closes #267 