### PR TITLE
Change DefaultSchemaVersion to not return an error

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -49,9 +49,8 @@ const (
 
 func newClaim(action string) claim.Claim {
 	now := time.Now()
-	schemaVersion, _ := claim.GetDefaultSchemaVersion()
 	return claim.Claim{
-		SchemaVersion: schemaVersion,
+		SchemaVersion: claim.GetDefaultSchemaVersion(),
 		ID:            "id",
 		Created:       now,
 		Installation:  "name",
@@ -402,12 +401,11 @@ func TestOpFromClaim_Environment(t *testing.T) {
 	c := newClaim(claim.ActionInstall)
 	invocImage := c.Bundle.InvocationImages[0]
 
-	schemaVersion, _ := claim.GetDefaultSchemaVersion()
 	expectedEnv := map[string]string{
 		"CNAB_ACTION":            "install",
 		"CNAB_BUNDLE_NAME":       "bar",
 		"CNAB_BUNDLE_VERSION":    "0.1.0",
-		"CNAB_CLAIMS_VERSION":    string(schemaVersion),
+		"CNAB_CLAIMS_VERSION":    string(claim.GetDefaultSchemaVersion()),
 		"CNAB_INSTALLATION_NAME": "name",
 		"CNAB_REVISION":          "revision",
 		"SECRET_ONE":             "I'm a secret",

--- a/action/example_install_test.go
+++ b/action/example_install_test.go
@@ -24,15 +24,10 @@ func Example_install() {
 	// Create the action that will execute the operation
 	a := action.New(d)
 
-	schemaVersion, err := bundle.GetDefaultSchemaVersion()
-	if err != nil {
-		panic(err)
-	}
-
 	// Get the definition of the bundle, usually you get this by pulling
 	// the bundle from an OCI registry using github.com/cnabio/cnab-to-oci
 	b := bundle.Bundle{
-		SchemaVersion: schemaVersion,
+		SchemaVersion: bundle.GetDefaultSchemaVersion(),
 		Name:          "mybuns",
 		Version:       "1.0.0",
 		InvocationImages: []bundle.InvocationImage{

--- a/action/example_upgrade_test.go
+++ b/action/example_upgrade_test.go
@@ -102,13 +102,8 @@ func Example_upgrade() {
 }
 
 func createInstallClaim() claim.Claim {
-	schemaVersion, err := bundle.GetDefaultSchemaVersion()
-	if err != nil {
-		panic(err)
-	}
-
 	b := bundle.Bundle{
-		SchemaVersion: schemaVersion,
+		SchemaVersion: bundle.GetDefaultSchemaVersion(),
 		Name:          "mybuns",
 		Version:       "1.0.0",
 		InvocationImages: []bundle.InvocationImage{

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -44,14 +44,18 @@ type Bundle struct {
 	Custom map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
+// validate the schema version at build time
+var _ schema.Version = GetDefaultSchemaVersion()
+
 // GetDefaultSchemaVersion returns the default semver CNAB schema version of the Bundle
 // that this library implements
-func GetDefaultSchemaVersion() (schema.Version, error) {
+func GetDefaultSchemaVersion() schema.Version {
 	ver, err := schema.GetSemver(CNABSpecVersion)
 	if err != nil {
-		return "", err
+		// We check that this can compile at build time, so if this fails, something is seriously wrong
+		panic(err)
 	}
-	return ver, nil
+	return ver
 }
 
 // Marshal the bundle to canonical json.

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -175,9 +175,8 @@ func TestMarshal_New(t *testing.T) {
 	assert.Equal(t, string(wantClaim), gotClaim, "marshaled claim does not match expected")
 }
 
-var schemaVersion, _ = GetDefaultSchemaVersion()
 var exampleClaim = Claim{
-	SchemaVersion:   schemaVersion,
+	SchemaVersion:   GetDefaultSchemaVersion(),
 	ID:              staticID,
 	Installation:    "my_claim",
 	Revision:        staticRevision,


### PR DESCRIPTION
There isn't really a need to force people to handle (or ignore) an error from DefaultSchemaVersion. The default schema is hard coded and with tests and buildtime asserts, we know that it was set to a valid value.

We were already throwing a panic or ignoring the error anyway at runtime, so this is more of an assurance actually than what we had before.