### PR TITLE
Fix panic when op.Err is unset in Docker driver

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	unix_path "path"
 	"strconv"
 	"strings"
@@ -244,14 +245,18 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		return driver.OperationResult{}, fmt.Errorf("unable to retrieve logs: %v", err)
 	}
 	var (
-		stdout = op.Out
-		stderr = op.Err
+		stdout io.Writer = os.Stdout
+		stderr io.Writer = os.Stderr
 	)
 	if d.containerOut != nil {
 		stdout = d.containerOut
+	} else if op.Out != nil {
+		stdout = op.Out
 	}
 	if d.containerErr != nil {
 		stderr = d.containerErr
+	} else if op.Err != nil {
+		stderr = op.Err
 	}
 	go func() {
 		defer attach.Close()


### PR DESCRIPTION
The op.Err field was added after the docker driver was first written. I noticed that when the caller of the docker driver doesn't set op.Err it causes a panic when we attach to the container's logs.

This fixes our defaulting of where we write errors so that we are never writing to a nil writer accidentally.

~It is based on #279 so I will rebase after that is merged.~