### PR TITLE
Fix unmarshal for claim results

### DIFF
--- a/claim/result.go
+++ b/claim/result.go
@@ -100,15 +100,13 @@ func (r Results) Swap(i, j int) {
 // OutputMetadata is the output metadata from an operation.
 // Any metadata can be stored, however this provides methods
 // for safely querying and retrieving well-known metadata.
-type OutputMetadata map[string]interface{}
+type OutputMetadata map[string]map[string]string
 
 // GetMetadata for the specified output and key.
 func (o OutputMetadata) GetMetadata(outputName string, metadataKey string) (string, bool) {
 	if output, ok := o[outputName]; ok {
-		if outputMetadata, ok := output.(map[string]string); ok {
-			if value, ok := outputMetadata[metadataKey]; ok {
-				return value, true
-			}
+		if value, ok := output[metadataKey]; ok {
+			return value, true
 		}
 	}
 
@@ -122,18 +120,13 @@ func (o *OutputMetadata) SetMetadata(outputName string, metadataKey string, valu
 	}
 	metadata := *o
 
-	output, ok := metadata[outputName]
+	outputMetadata, ok := metadata[outputName]
 	if !ok {
-		output = map[string]string{
+		outputMetadata = map[string]string{
 			metadataKey: value,
 		}
-		metadata[outputName] = output
+		metadata[outputName] = outputMetadata
 		return nil
-	}
-
-	outputMetadata, ok := output.(map[string]string)
-	if !ok {
-		return errors.Errorf("cannot set the claim result's OutputMetadata[%s][%s] because it is not type map[string]string but %T", outputName, metadataKey, output)
 	}
 
 	outputMetadata[metadataKey] = value

--- a/claim/testdata/result.json
+++ b/claim/testdata/result.json
@@ -1,0 +1,16 @@
+{
+  "id": "01G1VJH2HP97B5B0N5S37KYMVG",
+  "claimId": "01G1VJGY43HT3KZN82DS6DDPWK",
+  "created": "2022-04-29T16:09:47.190534-05:00",
+  "status": "succeeded",
+  "outputs": {
+    "io.cnab.outputs.invocationImageLogs": {
+      "contentDigest": "sha256:28ccd0529aa1edefb0e771a28c31c0193f656718af985fed197235ba98fc5696",
+      "generatedByBundle": "false"
+    },
+    "output1": {
+      "contentDigest": "sha256:abc123",
+      "generatedByBundle": "true"
+    }
+  }
+}


### PR DESCRIPTION
Originally we were defining output metadata as a map[string]interface{}, and then just casting as needed any output metadata values to map[string]string. This worked fine when setting and then immediately checking values, because we set the metadata correctly to begin with.

When a result is unmarshaled though, the json decoder is unmarshaling the output metadata values as map[string]interface{} and this prevented the helper methods for reading the metadata from working.

I've updated the OutputMetadata type to be map[string]map[string]string so that we aren't relying on casts working, and to give the json decoder the hint it needs to initialize the types correctly.