### PR TITLE
Fix installation of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,23 +48,20 @@ ifndef HAS_GOLANGCI
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_VERSION)
 endif
 ifndef HAS_KIND
-	go get sigs.k8s.io/kind@v0.11.1
+	go install sigs.k8s.io/kind@v0.11.1
 endif
 ifndef HAS_KUBECTL
 	echo "Follow instructions at https://kubernetes.io/docs/tasks/tools/install-kubectl/ to install kubectl."
 endif
 ifndef HAS_GOCOV_XML
-	go get github.com/AlekSi/gocov-xml
+	go install github.com/AlekSi/gocov-xml@v1.0.0
 endif
 ifndef HAS_GOCOV
-	go get github.com/axw/gocov/gocov@v1.0.0
+	go install github.com/axw/gocov/gocov@v1.0.0
 endif
 ifndef HAS_GO_JUNIT_REPORT
-	go get github.com/jstemmer/go-junit-report@v0.9.1
+	go install github.com/jstemmer/go-junit-report@v0.9.1
 endif
-
-	@# go get to install global tools with modules modify our dependencies. Reset them back
-	git checkout go.mod go.sum
 
 .PHONY: coverage
 coverage: compile-integration-tests

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ delete-test-cluster:
 
 GOPATH := $(shell go env GOPATH)
 HAS_GOLANGCI := $(shell $(CHECK) golangci-lint)
-GOLANGCI_VERSION := v1.21.0
+GOLANGCI_VERSION := v1.46.2
 HAS_KIND := $(shell $(CHECK) kind)
 HAS_KUBECTL := $(shell $(CHECK) kubectl)
 HAS_GOCOV_XML := $(shell $(CHECK) gocov-xml;)
@@ -45,7 +45,7 @@ HAS_GO_JUNIT_REPORT := $(shell $(CHECK) go-junit-report;)
 bootstrap:
 
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_VERSION)
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_VERSION)
 endif
 ifndef HAS_KIND
 	go get sigs.k8s.io/kind@v0.11.1

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -310,11 +310,11 @@ func TestNewULID_ThreadSafe(t *testing.T) {
 			for j := 0; j < 1000; j++ {
 				next, err := NewULID()
 				if err != nil {
-					t.Fatal(err)
+					panic(err)
 				}
 
 				if strings.Compare(next, last) != 1 {
-					t.Fatal("generated a ULID that was not monotonically increasing")
+					panic("generated a ULID that was not monotonically increasing")
 				}
 				last = next
 			}

--- a/driver/command/command_nix.go
+++ b/driver/command/command_nix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package command

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package command

--- a/driver/command/command_windows.go
+++ b/driver/command/command_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package command

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -166,6 +166,7 @@ func (d *Driver) initializeDockerCli() (command.Cli, error) {
 	if d.dockerCli != nil {
 		return d.dockerCli, nil
 	}
+
 	cli, err := command.NewDockerCli()
 	if err != nil {
 		return nil, err

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package docker

--- a/driver/kubernetes/kubernetes_integration_test.go
+++ b/driver/kubernetes/kubernetes_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kubernetes


### PR DESCRIPTION
However we were installing golangci-lint before (using their special install script) doesn't work on our CI anymore, or my local machine. I've updated to the most recent version of golangci-lint so that I could test it locally on my arm64 machine, and switch to using go install to install the tool.

I've also updated the code quick to get the `make lint` target passing again:
* Run go fmt over project
* Do not use testing.T helper from an anonymous function