### PR TITLE
Add github action that builds project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Bootstrap
+        run: make bootstrap
+      - name: Build
+        run: make fetch-schemas build
+      - name: Build (Windows)
+        run: GOOS=windows make build
+      - name: Build (Darwin)
+        run: GOOS=darwin make build 
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make coverage


### PR DESCRIPTION
I've converted our Azure DevOps Pipeline to a GitHub Workflow. I split out calling each target so that it's easier to find which step failed and repeat just failing steps in the build.

This is using the newer setup-go github action that has built in support for detecting which version of go to use based on the go.mod file and also caching downloaded go mods to speed up subsequent builds.