### PR TITLE
fix: avoid erasing local schema if fetching schema from cdn.cnab.io fails

### DIFF
--- a/fetch-schemas.go
+++ b/fetch-schemas.go
@@ -27,6 +27,8 @@ func main() {
 		bytes, err := fetchSchema(schema, version)
 		if err != nil {
 			fmt.Printf("unable to fetch %s schema with version %s: %s\n", schema, version, err.Error())
+			// if cdn.cnab.io is not reachable, we stick with default schema
+			return
 		}
 
 		err = writeSchema(schema, bytes)

--- a/fetch-schemas.go
+++ b/fetch-schemas.go
@@ -28,7 +28,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("unable to fetch %s schema with version %s: %s\n", schema, version, err.Error())
 			// if cdn.cnab.io is not reachable, we stick with default schema
-			return
+			continue
 		}
 
 		err = writeSchema(schema, bytes)


### PR DESCRIPTION
# Motivation

Fixes #287

Everything is detailled in [this comment](https://github.com/cnabio/cnab-go/issues/287#issuecomment-1158289217), but, TLDR: The CI is using the `fetch-schemas` go program to download the latest schema data files from the cnab cdn. If it doesn't reply for some reason, the program is erasing the local version of the schema file by an empty file, which can cause 2 tests to fail:

- `TestClaimSchema`
- `TestBundleSchema`

This PR is adding a return when the fetch request fails, so that we don't write an empty file on the disk when it fails and so that the tests don't fail in that case.

## Reproducing the issue

The issue can be reproduced by running locally `go run fetch-schemas.go`. If you run this command before this PR, after turning off your internet connection (eg wifi), you will see that both files gets erased. After the PR, the files are not updated anymore (with an empty content) when you run this command without an internet connection.

## Discussion

There's still a possibility that we don't want that PR, especially in the case that we want to be conservative and fail if we don't have the exact version of the spec we need (especially if we don't think the version in the repo is up to date). In that case maybe we would like the tests to fail rather than maybe releasing a false negative (if the version in the repo is not the same than the version upstream on the CDN).