### PR TITLE
Export "BuildDockerClientOptions"

### DIFF
--- a/driver/docker/client.go
+++ b/driver/docker/client.go
@@ -29,21 +29,21 @@ func GetDockerClient() (*command.DockerCli, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not create new docker client: %w", err)
 	}
-	opts := buildDockerClientOptions()
+	opts := BuildDockerClientOptions()
 	if err = cli.Initialize(opts); err != nil {
 		return nil, fmt.Errorf("error initializing docker client: %w", err)
 	}
 	return cli, nil
 }
 
-// manually handle DOCKER_TLS_VERIFY and DOCKER_CERT_PATH because the docker cli
+// BuildDockerClientOptions manually handles DOCKER_TLS_VERIFY and DOCKER_CERT_PATH because the docker cli
 // library only binds these values when initializing its cli flags. There isn't
 // other parts of the library that we can take advantage of to get these values
 // for "free".
 //
 // DOCKER_HOST however is retrieved dynamically later so that doesn't
 // require additional configuration.
-func buildDockerClientOptions() *cliflags.ClientOptions {
+func BuildDockerClientOptions() *cliflags.ClientOptions {
 	cliOpts := cliflags.NewClientOptions()
 	cliOpts.ConfigDir = cliconfig.Dir()
 

--- a/driver/docker/client_test.go
+++ b/driver/docker/client_test.go
@@ -27,7 +27,7 @@ func Test_buildDockerClientOptions(t *testing.T) {
 
 	t.Run("tls disabled", func(t *testing.T) {
 		os.Unsetenv(DockerTLSVerifyEnvVar)
-		opts := buildDockerClientOptions()
+		opts := BuildDockerClientOptions()
 		assert.False(t, opts.Common.TLS, "expected TLS to be disabled")
 		assert.False(t, opts.Common.TLSVerify, "expected TLSVerify to be disabled")
 		assert.Nil(t, opts.Common.TLSOptions, "expected TLSOptions to be unset")
@@ -40,7 +40,7 @@ func Test_buildDockerClientOptions(t *testing.T) {
 			os.Unsetenv(DockerTLSVerifyEnvVar)
 		}()
 
-		opts := buildDockerClientOptions()
+		opts := BuildDockerClientOptions()
 		assert.True(t, opts.Common.TLS, "expected TLS to be enabled")
 		assert.True(t, opts.Common.TLSVerify, "expected the certs to be verified")
 		assert.Equal(t, defaultTLSOptions, opts.Common.TLSOptions, "expected TLSOptions to be initialized to the default TLS settings")
@@ -54,7 +54,7 @@ func Test_buildDockerClientOptions(t *testing.T) {
 			os.Unsetenv(DockerCertPathEnvVar)
 		}()
 
-		opts := buildDockerClientOptions()
+		opts := BuildDockerClientOptions()
 		assert.True(t, opts.Common.TLS, "expected TLS to be enabled")
 		assert.True(t, opts.Common.TLSVerify, "expected the certs to be verified")
 		assert.Equal(t, customTLSOptions, opts.Common.TLSOptions, "expected TLSOptions to use the custom DOCKER_CERT_PATH set")
@@ -68,7 +68,7 @@ func Test_buildDockerClientOptions(t *testing.T) {
 			os.Unsetenv(DockerCertPathEnvVar)
 		}()
 
-		opts := buildDockerClientOptions()
+		opts := BuildDockerClientOptions()
 		assert.True(t, opts.Common.TLS, "expected TLS to be enabled")
 		assert.False(t, opts.Common.TLSVerify, "expected TLSVerify to be false")
 		assert.Equal(t, customTLSOptions, opts.Common.TLSOptions, "expected TLSOptions to use the custom DOCKER_CERT_PATH set")


### PR DESCRIPTION
This enables the configuration of already instanciated DockerCli