### PR TITLE
add pattern property to schema

### DIFF
--- a/bundle/definition/regexp.go
+++ b/bundle/definition/regexp.go
@@ -1,0 +1,18 @@
+package definition
+
+import (
+	"regexp"
+)
+
+type Regexp struct {
+	regexp.Regexp
+}
+
+func (r Regexp) MarshalBinary() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
+// UnmarshalBinary modifies the receiver so it must take a pointer receiver.
+func (r *Regexp) UnmarshalBinary(data []byte) error {
+	return r.UnmarshalText(data)
+}

--- a/bundle/definition/regexp_test.go
+++ b/bundle/definition/regexp_test.go
@@ -1,0 +1,53 @@
+package definition_test
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"encoding/gob"
+
+	"github.com/cnabio/cnab-go/bundle/definition"
+)
+
+func TestRegexp_Encode_Decode(t *testing.T) {
+	type fields struct {
+		Regexp regexp.Regexp
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "1",
+			fields: fields{
+				Regexp: *regexp.MustCompile(`/^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$/u`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			enc := gob.NewEncoder(&buf)
+			r := definition.Regexp{
+				Regexp: tt.fields.Regexp,
+			}
+			err := enc.Encode(r)
+			if err != nil {
+				t.Error(err)
+			}
+
+			dec := gob.NewDecoder(&buf)
+			v := definition.Regexp{}
+			err = dec.Decode(&v)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if v.String() != r.String() {
+				t.Errorf("Regexp.MarshalBinary() = %v, want %v", v.String(), r.String())
+			}
+		})
+	}
+}

--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -2,7 +2,6 @@ package definition
 
 import (
 	"encoding/json"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -46,7 +45,7 @@ type Schema struct {
 	MultipleOf        *float64           `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	Not               *Schema            `json:"not,omitempty" yaml:"not,omitempty"`
 	OneOf             *Schema            `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-	Pattern           *regexp.Regexp     `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Pattern           *Regexp            `json:"pattern,omitempty" yaml:"pattern,omitempty"`
 	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
 
 	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`

--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -2,6 +2,7 @@ package definition
 
 import (
 	"encoding/json"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,17 +36,17 @@ type Schema struct {
 	Format               string                 `json:"format,omitempty" yaml:"format,omitempty"`
 	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty"`
 	//Items can be a Schema or an Array of Schema :(
-	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty"`
-	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	MaxLength     *int        `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MinItems      *int        `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	MinLength     *int        `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	MinProperties *int        `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
-	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty"`
-	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-
+	Items             interface{}        `json:"items,omitempty" yaml:"items,omitempty"`
+	Maximum           *float64           `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MaxLength         *int               `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinItems          *int               `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength         *int               `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinProperties     *int               `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	Minimum           *float64           `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf        *float64           `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Not               *Schema            `json:"not,omitempty" yaml:"not,omitempty"`
+	OneOf             *Schema            `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	Pattern           *regexp.Regexp     `json:"pattern,omitempty" yaml:"pattern,omitempty"`
 	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
 
 	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`

--- a/bundle/definition/validation_test.go
+++ b/bundle/definition/validation_test.go
@@ -41,6 +41,21 @@ func TestObjectValidationValid(t *testing.T) {
 	assert.Len(t, valErrors, 0, "expected no validation errors")
 	assert.NoError(t, err)
 }
+func TestPatternValidationValid(t *testing.T) {
+	s := `{
+		"type": "string",
+		"pattern" : "^[0-9]{3}-[0-9]{4}$"
+	}`
+	definition := new(Schema)
+	err := json.Unmarshal([]byte(s), definition)
+	require.NoError(t, err, "should have been able to marshall definition")
+	assert.Equal(t, "string", definition.Type, "type should have been an object")
+
+	val := "124-1234"
+	valErrors, err := definition.Validate(val)
+	assert.Len(t, valErrors, 0, "expected no validation errors")
+	assert.NoError(t, err)
+}
 
 func TestObjectValidationValid_CustomValidator_ContentEncoding_base64(t *testing.T) {
 	s := `{


### PR DESCRIPTION
jsonschema specification has pattern validator for string parameters https://json-schema.org/draft/2020-12/json-schema-validation#name-contentencoding.
Add Pattern field to Schema to allow this validation.