### PR TITLE
Capture outputs on context cancellation

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -46,6 +46,7 @@ type Driver struct {
 type ContainerResultClient interface {
 	ContainerWait(ctx context.Context, containerID string, options client.ContainerWaitOptions) client.ContainerWaitResult
 	ContainerStop(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error)
+	CopyFromContainer(ctx context.Context, containerID string, options client.CopyFromContainerOptions) (client.CopyFromContainerResult, error)
 }
 
 // Run executes the Docker driver
@@ -288,24 +289,38 @@ func (d *Driver) getContainerResult(ctx context.Context, cliClient ContainerResu
 		if err != nil {
 			return driver.OperationResult{}, err
 		}
-		return driver.OperationResult{}, ctx.Err()
+		// Wait for the container to fully exit so all output files are flushed
+		// before we copy them — mirrors what the normal exit path does via
+		// WaitConditionNotRunning.
+		exitWait := cliClient.ContainerWait(context.Background(), d.containerID, client.ContainerWaitOptions{
+			Condition: container.WaitConditionNotRunning,
+		})
+		select {
+		case <-exitWait.Result:
+		case <-exitWait.Error:
+		}
+		opResult, fetchErr := d.fetchOutputs(context.Background(), cliClient, d.containerID, op)
+		if fetchErr != nil {
+			return opResult, fmt.Errorf("fetching outputs failed: %w; %w", fetchErr, ctx.Err())
+		}
+		return opResult, ctx.Err()
 	case err := <-waitResult.Error:
 		if err != nil {
-			opResult, fetchErr := d.fetchOutputs(ctx, d.containerID, op)
+			opResult, fetchErr := d.fetchOutputs(ctx, cliClient, d.containerID, op)
 			return opResult, containerError("error in container", err, fetchErr)
 		}
 	case s := <-waitResult.Result:
 		if s.StatusCode == 0 {
-			return d.fetchOutputs(ctx, d.containerID, op)
+			return d.fetchOutputs(ctx, cliClient, d.containerID, op)
 		}
 		if s.Error != nil {
-			opResult, fetchErr := d.fetchOutputs(ctx, d.containerID, op)
+			opResult, fetchErr := d.fetchOutputs(ctx, cliClient, d.containerID, op)
 			return opResult, containerError(fmt.Sprintf("container exit code: %d, message", s.StatusCode), nil, fetchErr)
 		}
-		opResult, fetchErr := d.fetchOutputs(ctx, d.containerID, op)
+		opResult, fetchErr := d.fetchOutputs(ctx, cliClient, d.containerID, op)
 		return opResult, containerError(fmt.Sprintf("container exit code: %d, message", s.StatusCode), nil, fetchErr)
 	}
-	opResult, fetchErr := d.fetchOutputs(ctx, d.containerID, op)
+	opResult, fetchErr := d.fetchOutputs(ctx, cliClient, d.containerID, op)
 	if fetchErr != nil {
 		return opResult, fmt.Errorf("fetching outputs failed: %s", fetchErr)
 	}
@@ -373,7 +388,7 @@ func containerError(containerMessage string, containerErr, fetchErr error) error
 // fetchOutputs takes a context and a container ID; it copies the /cnab/app/outputs directory from that container.
 // The goal is to collect all the files in the directory (recursively) and put them in a flat map of path to contents.
 // This map will be inside the OperationResult. When fetchOutputs returns an error, it may also return partial results.
-func (d *Driver) fetchOutputs(ctx context.Context, container string, op *driver.Operation) (driver.OperationResult, error) {
+func (d *Driver) fetchOutputs(ctx context.Context, cliClient ContainerResultClient, container string, op *driver.Operation) (driver.OperationResult, error) {
 	opResult := driver.OperationResult{
 		Outputs: map[string]string{},
 	}
@@ -383,7 +398,7 @@ func (d *Driver) fetchOutputs(ctx context.Context, container string, op *driver.
 	if len(op.Outputs) == 0 {
 		return opResult, nil
 	}
-	copyResult, err := d.dockerCli.Client().CopyFromContainer(ctx, container, client.CopyFromContainerOptions{
+	copyResult, err := cliClient.CopyFromContainer(ctx, container, client.CopyFromContainerOptions{
 		SourcePath: "/cnab/app/outputs",
 	})
 	if err != nil {

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -295,13 +295,18 @@ func (d *Driver) getContainerResult(ctx context.Context, cliClient ContainerResu
 		exitWait := cliClient.ContainerWait(context.Background(), d.containerID, client.ContainerWaitOptions{
 			Condition: container.WaitConditionNotRunning,
 		})
+		var waitErr error
 		select {
 		case <-exitWait.Result:
-		case <-exitWait.Error:
+		case err := <-exitWait.Error:
+			waitErr = err
 		}
 		opResult, fetchErr := d.fetchOutputs(context.Background(), cliClient, d.containerID, op)
 		if fetchErr != nil {
 			return opResult, fmt.Errorf("fetching outputs failed: %w; %w", fetchErr, ctx.Err())
+		}
+		if waitErr != nil {
+			return opResult, fmt.Errorf("container wait failed: %w; %w", waitErr, ctx.Err())
 		}
 		return opResult, ctx.Err()
 	case err := <-waitResult.Error:

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -261,7 +261,7 @@ func TestDriver_Run_ContextCancellation(t *testing.T) {
 	opResult, err := docker.Run(ctx, op)
 
 	require.Error(t, err, "expected Run to return an error when context is cancelled")
-	assert.Equal(t, driver.OperationResult{}, opResult)
+	assert.Equal(t, driver.OperationResult{Outputs: map[string]string{}}, opResult)
 
 	loopMax := 50
 	loopCount := 0

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -292,3 +292,81 @@ func TestDriver_Run_ContextCancellation(t *testing.T) {
 		}
 	}
 }
+
+func TestDriver_Run_ContextCancellation_OutputsCaptured(t *testing.T) {
+	// Container writes an output file then sleeps; verify the output is
+	// captured even though the context is cancelled before the container exits.
+	image := bundle.InvocationImage{
+		BaseImage: bundle.BaseImage{
+			Image: "busybox:latest",
+		},
+	}
+
+	op := &driver.Operation{
+		Installation: "test-cancel-outputs",
+		Action:       "install",
+		Image:        image,
+		Outputs: map[string]string{
+			"/cnab/app/outputs/myoutput": "myoutput",
+		},
+		Bundle: &bundle.Bundle{
+			Definitions: definition.Definitions{
+				"myoutput": &definition.Schema{},
+			},
+			Outputs: map[string]bundle.Output{
+				"myoutput": {
+					Definition: "myoutput",
+				},
+			},
+		},
+	}
+
+	var output bytes.Buffer
+	op.Out = &output
+	op.Environment = map[string]string{
+		"CNAB_ACTION":            op.Action,
+		"CNAB_INSTALLATION_NAME": op.Installation,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dockerCli, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+	defer dockerCli.Close()
+
+	docker := &Driver{}
+	docker.AddConfigurationOptions(func(cfg *container.Config, hostCfg *container.HostConfig) error {
+		// Write the output file then sleep so context cancellation arrives mid-run.
+		cfg.Entrypoint = []string{"sh", "-c", "mkdir -p /cnab/app/outputs && printf 'hello-output' > /cnab/app/outputs/myoutput && sleep 300"}
+		return nil
+	})
+
+	// Cancel once the container is running and has had time to write its output.
+	go func() {
+		for {
+			containers, err := dockerCli.ContainerList(context.Background(), client.ContainerListOptions{})
+			require.NoError(t, err)
+			found := false
+			for _, c := range containers.Items {
+				if c.ID == docker.containerID && c.State == container.StateRunning {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+			fmt.Println("Waiting for container to start...")
+			time.Sleep(time.Millisecond * 100)
+		}
+		// Brief pause so the entrypoint has time to write the file before we cancel.
+		time.Sleep(time.Millisecond * 200)
+		cancel()
+	}()
+
+	opResult, err := docker.Run(ctx, op)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotNil(t, opResult.Outputs)
+	assert.Equal(t, "hello-output", opResult.Outputs["myoutput"])
+}

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -1,8 +1,11 @@
 package docker
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
@@ -256,21 +259,36 @@ func TestGetContainerUserId(t *testing.T) {
 }
 
 type MockContainerResultClient struct {
-	ContainerStopId    string
-	ContainerStopError error
+	ContainerStopId     string
+	ContainerStopError  error
+	CopyFromContainerFn func(ctx context.Context, containerID string, options client.CopyFromContainerOptions) (client.CopyFromContainerResult, error)
+	containerWaitCalls  int
 }
 
 func (m *MockContainerResultClient) ContainerWait(ctx context.Context, containerID string, options client.ContainerWaitOptions) client.ContainerWaitResult {
+	m.containerWaitCalls++
 	statusCh := make(chan container.WaitResponse, 1)
 	errCh := make(chan error, 1)
+	if m.containerWaitCalls > 1 {
+		// Subsequent calls are the post-stop exitWait; signal the container has exited.
+		statusCh <- container.WaitResponse{StatusCode: 0}
+	}
 	return client.ContainerWaitResult{
 		Result: statusCh,
 		Error:  errCh,
 	}
 }
+
 func (m *MockContainerResultClient) ContainerStop(ctx context.Context, containerID string, options client.ContainerStopOptions) (client.ContainerStopResult, error) {
 	m.ContainerStopId = containerID
 	return client.ContainerStopResult{}, m.ContainerStopError
+}
+
+func (m *MockContainerResultClient) CopyFromContainer(ctx context.Context, containerID string, options client.CopyFromContainerOptions) (client.CopyFromContainerResult, error) {
+	if m.CopyFromContainerFn != nil {
+		return m.CopyFromContainerFn(ctx, containerID, options)
+	}
+	return client.CopyFromContainerResult{}, nil
 }
 
 func TestDriver_exec_ContextCancellation(t *testing.T) {
@@ -288,13 +306,59 @@ func TestDriver_exec_ContextCancellation(t *testing.T) {
 			},
 		}
 
-		client := &MockContainerResultClient{}
+		mockClient := &MockContainerResultClient{}
 
-		result, err := d.getContainerResult(ctx, client, op)
+		result, err := d.getContainerResult(ctx, mockClient, op)
 
-		assert.Error(t, err, "expected Run to return an error with cancelled context")
-		assert.Equal(t, driver.OperationResult{}, result)
-		assert.Equal(t, d.containerID, client.ContainerStopId)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, driver.OperationResult{Outputs: map[string]string{}}, result)
+		assert.Equal(t, d.containerID, mockClient.ContainerStopId)
+	})
+}
+
+func TestDriver_exec_ContextCancellation_OutputsCaptured(t *testing.T) {
+	t.Run("outputs are captured after context cancellation", func(t *testing.T) {
+		const containerID = "unit-test-container-id"
+		d := &Driver{containerID: containerID}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		op := &driver.Operation{
+			Image: bundle.InvocationImage{
+				BaseImage: bundle.BaseImage{Image: "test-image"},
+			},
+			Outputs: map[string]string{
+				"/cnab/app/outputs/myoutput": "myoutput",
+			},
+		}
+
+		// Build a TAR that mimics what CopyFromContainer returns.
+		// CopyFromContainer strips the leading path so the header name is
+		// "outputs/myoutput".
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		content := []byte("hello-output")
+		_ = tw.WriteHeader(&tar.Header{
+			Name: "outputs/myoutput",
+			Size: int64(len(content)),
+		})
+		_, _ = tw.Write(content)
+		tw.Close()
+		tarBytes := buf.Bytes()
+
+		mockClient := &MockContainerResultClient{
+			CopyFromContainerFn: func(_ context.Context, _ string, _ client.CopyFromContainerOptions) (client.CopyFromContainerResult, error) {
+				return client.CopyFromContainerResult{Content: io.NopCloser(bytes.NewReader(tarBytes))}, nil
+			},
+		}
+
+		result, err := d.getContainerResult(ctx, mockClient, op)
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, containerID, mockClient.ContainerStopId)
+		require.NotNil(t, result.Outputs)
+		assert.Equal(t, "hello-output", result.Outputs["myoutput"])
 	})
 }
 
@@ -311,14 +375,14 @@ func TestDriver_exec_ContextCancellationError(t *testing.T) {
 			},
 		}
 
-		client := &MockContainerResultClient{
+		mockClient := &MockContainerResultClient{
 			ContainerStopError: fmt.Errorf("unit-test-error"),
 		}
 
-		result, err := d.getContainerResult(ctx, client, op)
+		result, err := d.getContainerResult(ctx, mockClient, op)
 
 		assert.Error(t, err, "expected Run to return an error with cancelled context")
 		assert.Equal(t, driver.OperationResult{}, result)
-		assert.Equal(t, err, client.ContainerStopError)
+		assert.Equal(t, err, mockClient.ContainerStopError)
 	})
 }

--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -339,12 +339,13 @@ func TestDriver_exec_ContextCancellation_OutputsCaptured(t *testing.T) {
 		var buf bytes.Buffer
 		tw := tar.NewWriter(&buf)
 		content := []byte("hello-output")
-		_ = tw.WriteHeader(&tar.Header{
+		require.NoError(t, tw.WriteHeader(&tar.Header{
 			Name: "outputs/myoutput",
 			Size: int64(len(content)),
-		})
-		_, _ = tw.Write(content)
-		tw.Close()
+		}))
+		_, werr := tw.Write(content)
+		require.NoError(t, werr)
+		require.NoError(t, tw.Close())
 		tarBytes := buf.Bytes()
 
 		mockClient := &MockContainerResultClient{


### PR DESCRIPTION
## What does this change

In `driver/docker/docker.go`, the `case <-ctx.Done()` branch of `getContainerResult` called `ContainerStop` but then returned an empty `OperationResult{}` without calling `fetchOutputs`. Outputs written to `/cnab/app/outputs/` during graceful shutdown (including porter-state) were silently dropped.

This is the cnab-go fix referenced in [getporter/porter#3603](https://github.com/getporter/porter/pull/3603).

## Changes

- **`ContainerResultClient` interface**: added `CopyFromContainer` so `fetchOutputs` can be driven through the same mockable interface as `ContainerWait`/`ContainerStop`, enabling unit tests without a live Docker CLI.
- **`fetchOutputs`**: accepts `ContainerResultClient` instead of calling `d.dockerCli.Client()` directly.
- **`ctx.Done` branch**: after `ContainerStop`, waits for `WaitConditionNotRunning` (mirroring the normal exit path) before calling `fetchOutputs`, ensuring output files are fully flushed before `CopyFromContainer` reads them. Both `fetchErr` and `ctx.Err()` are wrapped in the error return so callers can still detect cancellation even if fetching also fails.

## Tests

- `TestDriver_exec_ContextCancellation` — updated to assert `context.Canceled` is returned and `Outputs` map is populated (not nil) after cancellation.
- `TestDriver_exec_ContextCancellation_OutputsCaptured` — new test: verifies that outputs written to `/cnab/app/outputs/` are captured and returned when the context is cancelled.
- `MockContainerResultClient` — extended with `CopyFromContainerFn` and a call counter so the post-stop `ContainerWait` returns immediately in tests.