### PR TITLE
Treat a null bundle definition as absent instead of panicking

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -212,7 +212,7 @@ func ValuesOrDefaults(vals map[string]interface{}, b *Bundle, action string) (ma
 			continue
 		}
 		s, ok := b.Definitions[param.Definition]
-		if !ok {
+		if !ok || s == nil {
 			return res, fmt.Errorf("unable to find definition for %s", name)
 		}
 

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -950,6 +950,55 @@ func TestBundle_IsOutputSensitive(t *testing.T) {
 
 }
 
+// A bundle.json can carry a null definition, e.g. "definitions": {"nullDef": null}.
+// Because Definitions is a map of *Schema, the map lookup succeeds with ok == true
+// but hands back a nil pointer, which used to panic when it was dereferenced. A nil
+// definition should be treated the same as a missing one.
+func TestBundle_NilDefinition(t *testing.T) {
+	b := &Bundle{
+		SchemaVersion: "1.2.0",
+		InvocationImages: []InvocationImage{
+			{
+				BaseImage: BaseImage{
+					Image:     "foo/bar:1.0.0",
+					ImageType: "docker",
+				},
+			},
+		},
+		Definitions: map[string]*definition.Schema{
+			"nullDef": nil,
+		},
+		Parameters: map[string]Parameter{
+			"someParam": {
+				Definition: "nullDef",
+			},
+		},
+		Outputs: map[string]Output{
+			"someOutput": {
+				Definition: "nullDef",
+			},
+		},
+	}
+
+	t.Run("Validate does not panic", func(t *testing.T) {
+		// The nil definition is treated as missing, so validation reports the
+		// missing definition rather than dereferencing a nil pointer.
+		err := b.Validate()
+		require.Error(t, err, "expected a definition-not-found error, not a panic")
+	})
+
+	t.Run("ValuesOrDefaults does not panic", func(t *testing.T) {
+		_, err := ValuesOrDefaults(map[string]interface{}{}, b, "install")
+		require.Error(t, err, "expected a definition-not-found error, not a panic")
+	})
+
+	t.Run("IsOutputSensitive does not panic", func(t *testing.T) {
+		sensitive, err := b.IsOutputSensitive("someOutput")
+		require.Error(t, err, "expected a definition-not-found error, not a panic")
+		assert.False(t, sensitive)
+	})
+}
+
 func TestBundle_GetAction(t *testing.T) {
 	testcases := []struct {
 		action    string

--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -29,7 +29,7 @@ func (o Output) AppliesTo(action string) bool {
 // value is sensitive.
 func (b Bundle) IsOutputSensitive(outputName string) (bool, error) {
 	if output, ok := b.Outputs[outputName]; ok {
-		if def, ok := b.Definitions[output.Definition]; ok {
+		if def, ok := b.Definitions[output.Definition]; ok && def != nil {
 			sensitive := def.WriteOnly != nil && *def.WriteOnly
 			return sensitive, nil
 		}
@@ -48,7 +48,7 @@ func (o *Output) Validate(name string, bun Bundle) error {
 
 	// Validate default against definition schema, if exists
 	schema, ok := bun.Definitions[o.Definition]
-	if !ok {
+	if !ok || schema == nil {
 		return fmt.Errorf("unable to find definition for %s", name)
 	}
 	var valResult *multierror.Error

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -35,7 +35,7 @@ func (p *Parameter) Validate(name string, bun Bundle) error {
 
 	// Validate default against definition schema, if exists
 	schema, ok := bun.Definitions[p.Definition]
-	if !ok {
+	if !ok || schema == nil {
 		return fmt.Errorf("unable to find definition for %s", name)
 	}
 	if schema.Default != nil {


### PR DESCRIPTION
Hi, thanks for maintaining cnab-go.

A bundle.json is allowed to carry a JSON null in its definitions map, for example:

```json
"definitions": { "foo": null }
```

Since Bundle.Definitions is a map[string]*Schema, that null gets stored as a nil pointer under the key. The common `value, ok := m[key]` idiom then returns ok == true with a nil *Schema, and the following dereference panics. The four places that look a definition up and then read a field off it are affected:

- `Parameter.Validate` (bundle/parameters.go) reading `schema.Default`
- `Output.Validate` (bundle/outputs.go) reading `schema.Default`
- `ValuesOrDefaults` (bundle/bundle.go) using `s` for coercion
- `IsOutputSensitive` (bundle/outputs.go) reading `def.WriteOnly`

So any caller that runs `Bundle.Validate`, `ValuesOrDefaults`, or `IsOutputSensitive` on a bundle that a user or another tool produced with a null definition crashes with a nil pointer dereference rather than getting an error back.

The fix guards the nil pointer at each site (`if !ok || schema == nil`, and `ok && def != nil` for the sensitivity check) so a null definition is handled the same way as a missing one. That reuses the existing not-found error path, so behavior for well-formed bundles is unchanged.

I added a regression test (TestBundle_NilDefinition) that builds a bundle with a null definition referenced by both a parameter and an output, and asserts Validate, ValuesOrDefaults, and IsOutputSensitive all return an error instead of panicking. It panics before the change and passes after. `go test ./bundle/...` is green.

Happy to adjust the approach if you would rather reject a null definition earlier during unmarshalling instead.