### PR TITLE
fix: block path traversal in k8s driver file writes

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -461,6 +461,9 @@ func injectParameters(c claim.Claim, env, files map[string]string) error {
 			continue
 		}
 		if param.Destination.Path != "" {
+			if err := param.Destination.Validate(); err != nil {
+				return fmt.Errorf("invalid destination for parameter %q: %w", k, err)
+			}
 			files[param.Destination.Path] = value
 		}
 		if param.Destination.EnvironmentVariable != "" {
@@ -489,6 +492,10 @@ func expandCredentials(b bundle.Bundle, set valuesource.Set, stateless bool, act
 			env[val.EnvironmentVariable] = src
 		}
 		if val.Path != "" {
+			if err = val.Location.Validate(); err != nil {
+				err = fmt.Errorf("invalid path for credential %q: %w", name, err)
+				return
+			}
 			files[val.Path] = src
 		}
 	}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -250,6 +250,34 @@ func TestOpFromClaim(t *testing.T) {
 	is.Nil(op.Out)
 }
 
+func TestOpFromClaim_RejectsTraversalParameterPath(t *testing.T) {
+	c := newClaim(claim.ActionInstall)
+	c.Bundle.Parameters["param_three"] = bundle.Parameter{
+		Definition:  "ParamThree",
+		Destination: &bundle.Location{Path: "/../../../../etc/cron.d/pwn"},
+	}
+	c.Parameters = map[string]interface{}{
+		"param_three": "threeval",
+	}
+	invocImage := c.Bundle.InvocationImages[0]
+
+	_, err := opFromClaim(stateful, c, invocImage, mockSet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid destination for parameter "param_three"`)
+}
+
+func TestOpFromClaim_RejectsTraversalCredentialPath(t *testing.T) {
+	c := newClaim(claim.ActionInstall)
+	c.Bundle.Credentials["secret_one"] = bundle.Credential{
+		Location: bundle.Location{Path: "/../../../../etc/cron.d/pwn"},
+	}
+	invocImage := c.Bundle.InvocationImages[0]
+
+	_, err := opFromClaim(stateful, c, invocImage, mockSet)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid path for credential "secret_one"`)
+}
+
 func TestOpFromClaim_NoOutputsOnBundle(t *testing.T) {
 	c := newClaim(claim.ActionInstall)
 	c.Bundle.Outputs = nil

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 
 	cjson "github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
@@ -171,6 +172,12 @@ type Location struct {
 
 // Validate the Location
 func (l Location) Validate() error {
+	if l.Path != "" {
+		if !path.IsAbs(l.Path) || path.Clean(l.Path) != l.Path {
+			return fmt.Errorf("Path %q must be an absolute, clean path", l.Path)
+		}
+	}
+
 	forbiddenPath := "/cnab/app/outputs"
 	if strings.HasPrefix(l.Path, forbiddenPath) {
 		return fmt.Errorf("Path %q must not be a subpath of %q", l.Path, forbiddenPath)

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -870,6 +870,18 @@ func TestValidateLocation(t *testing.T) {
 		name:     "error path",
 		location: Location{Path: "/cnab/app/outputs/thing"},
 		err:      `Path "/cnab/app/outputs/thing" must not be a subpath of "/cnab/app/outputs"`,
+	}, {
+		name:     "relative path traversal",
+		location: Location{Path: "../../../etc/passwd"},
+		err:      `Path "../../../etc/passwd" must be an absolute, clean path`,
+	}, {
+		name:     "absolute path traversal",
+		location: Location{Path: "/../../../etc/cron.d/x"},
+		err:      `Path "/../../../etc/cron.d/x" must be an absolute, clean path`,
+	}, {
+		name:     "non-absolute path",
+		location: Location{Path: "relative/path"},
+		err:      `Path "relative/path" must be an absolute, clean path`,
 	}}
 
 	for _, tc := range testCases {

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -415,16 +415,21 @@ func (k *Driver) Run(ctx context.Context, op *driver.Operation) (driver.Operatio
 	}
 
 	if len(op.Files) > 0 {
-		// Write the files to the inputs directory on the shared volume and mount them individually to the desired location in the invocation image
+		// Write the files to the inputs directory on the shared volume and mount them individually to the desired location in the invocation image.
+		// Use os.Root to confine writes to the inputs directory, since inputRelPath comes from the untrusted bundle.json and could otherwise escape via ".." segments or symlinks.
+		inputsRoot, err := os.OpenRoot(filepath.Join(k.JobVolumePath, "inputs"))
+		if err != nil {
+			return driver.OperationResult{}, errors.Wrapf(err, "error opening inputs directory on the shared job volume %s", k.JobVolumeName)
+		}
+		defer inputsRoot.Close()
+
 		for inputRelPath, contents := range op.Files {
-			inputPath := filepath.Join(k.JobVolumePath, "inputs", inputRelPath)
-			err = os.MkdirAll(filepath.Dir(inputPath), 0700)
-			if err != nil {
-				return driver.OperationResult{}, errors.Wrapf(err, "error creating directory for file %s on the shared job volume %s", inputPath, k.JobVolumeName)
+			relName := strings.TrimPrefix(inputRelPath, "/")
+			if err := inputsRoot.MkdirAll(filepath.Dir(relName), 0700); err != nil {
+				return driver.OperationResult{}, errors.Wrapf(err, "error creating directory for file %s on the shared job volume %s", inputRelPath, k.JobVolumeName)
 			}
-			err = ioutil.WriteFile(inputPath, []byte(contents), 0600)
-			if err != nil {
-				return driver.OperationResult{}, errors.Wrapf(err, "error writing file %s to the shared job volume %s", inputPath, k.JobVolumeName)
+			if err := inputsRoot.WriteFile(relName, []byte(contents), 0600); err != nil {
+				return driver.OperationResult{}, errors.Wrapf(err, "error writing file %s to the shared job volume %s", inputRelPath, k.JobVolumeName)
 			}
 
 			container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{

--- a/driver/kubernetes/kubernetes_test.go
+++ b/driver/kubernetes/kubernetes_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,61 @@ func TestDriver_RunWithSharedFiles(t *testing.T) {
 	inputContents, err := ioutil.ReadFile(wantInputFile)
 	require.NoErrorf(t, err, "could not read generated input file %s on shared volume", wantInputFile)
 	assert.Equal(t, "input value", string(inputContents), "invalid input file contents")
+}
+
+func TestDriver_RunWithSharedFiles_PathTraversal(t *testing.T) {
+	traversalPaths := []string{
+		"../../../etc/passwd",
+		"/../../../etc/cron.d/x",
+		"/cnab/app/../../../etc/shadow",
+	}
+
+	for _, traversalPath := range traversalPaths {
+		t.Run(traversalPath, func(t *testing.T) {
+			ctx := context.Background()
+			// Simulate the shared volume
+			sharedDir, err := ioutil.TempDir("", "cnab-go")
+			require.NoError(t, err, "could not create test directory")
+			defer os.RemoveAll(sharedDir)
+
+			client := fake.NewSimpleClientset()
+			namespace := "default"
+			k := Driver{
+				Namespace:          namespace,
+				jobs:               client.BatchV1().Jobs(namespace),
+				secrets:            client.CoreV1().Secrets(namespace),
+				pods:               client.CoreV1().Pods(namespace),
+				JobVolumePath:      sharedDir,
+				JobVolumeName:      "cnab-driver-shared",
+				SkipCleanup:        true,
+				skipJobStatusCheck: true,
+			}
+			op := driver.Operation{
+				Action: "install",
+				Image:  bundle.InvocationImage{BaseImage: bundle.BaseImage{Image: "foo/bar"}},
+				Bundle: &bundle.Bundle{},
+				Out:    os.Stdout,
+				Files: map[string]string{
+					traversalPath: "malicious content",
+				},
+			}
+
+			_, err = k.Run(ctx, &op)
+			assert.Error(t, err, "expected Run to reject a path-traversal input file")
+
+			// Confirm nothing was written outside of sharedDir/inputs
+			inputsDir := filepath.Join(sharedDir, "inputs")
+			err = filepath.Walk(sharedDir, func(path string, info os.FileInfo, err error) error {
+				require.NoError(t, err)
+				if info.IsDir() {
+					return nil
+				}
+				assert.Truef(t, strings.HasPrefix(path, inputsDir+string(filepath.Separator)), "file was written outside the inputs directory: %s", path)
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestImageWithDigest(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes GHSA-92c3-6gp6-45mv (critical, CVSS 9.6, CWE-22/CWE-73): untrusted `destination.path`/credential `path` from `bundle.json` let a malicious bundle write arbitrary files on the host running the kubernetes driver, via `filepath.Join(JobVolumePath, "inputs", inputRelPath)` with no containment check.
- `driver/kubernetes`: input files are now written via `os.Root` confined to `JobVolumePath/inputs`, blocking `..` traversal and symlink escapes (load-bearing fix).
- `bundle`: `Location.Validate()` now rejects non-absolute/non-clean paths, in addition to the existing `/cnab/app/outputs` check.
- `action`: `injectParameters`/`expandCredentials` now call `Location.Validate()` before adding an entry to `op.Files`.
- No public API behavior changed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./driver/kubernetes/... ./bundle/... ./action/...`
- [x] `go test ./...` (full suite)
- [x] New tests: traversal payloads rejected + writes contained in `driver/kubernetes/kubernetes_test.go`; `Location.Validate()` traversal cases in `bundle/bundle_test.go`; end-to-end rejection in `action/action_test.go`
- [x] Manually re-ran advisory PoC against patched `Location.Validate()`, confirmed rejection