### PR TITLE
fix: block path traversal in command driver reads

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -403,6 +403,11 @@ func opFromClaim(stateless bool, c claim.Claim, ii bundle.InvocationImage, creds
 	env["CNAB_INSTALLATION_NAME"] = c.Installation
 	env["CNAB_REVISION"] = c.Revision
 
+	outputs, err := getOutputsGeneratedByAction(c.Action, c.Bundle)
+	if err != nil {
+		return nil, err
+	}
+
 	return &driver.Operation{
 		Action:       c.Action,
 		Installation: c.Installation,
@@ -411,23 +416,27 @@ func opFromClaim(stateless bool, c claim.Claim, ii bundle.InvocationImage, creds
 		Revision:     c.Revision,
 		Environment:  env,
 		Files:        files,
-		Outputs:      getOutputsGeneratedByAction(c.Action, c.Bundle),
+		Outputs:      outputs,
 		Bundle:       &c.Bundle,
 	}, nil
 }
 
 // getOutputsGeneratedByAction returns a map of output paths to the name of the output, filtered by the specified action.
-func getOutputsGeneratedByAction(action string, b bundle.Bundle) map[string]string {
+func getOutputsGeneratedByAction(action string, b bundle.Bundle) (map[string]string, error) {
 	outputs := make(map[string]string, len(b.Outputs))
 	for outputName, outputDef := range b.Outputs {
 		if !outputDef.AppliesTo(action) {
 			continue
 		}
 
+		if err := outputDef.ValidatePath(); err != nil {
+			return nil, fmt.Errorf("invalid path for output %q: %w", outputName, err)
+		}
+
 		outputs[outputDef.Path] = outputName
 	}
 
-	return outputs
+	return outputs, nil
 }
 
 func injectParameters(c claim.Claim, env, files map[string]string) error {

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -129,7 +129,7 @@ func mockBundle() bundle.Bundle {
 		},
 		Outputs: map[string]bundle.Output{
 			"some-output": {
-				Path:       "/tmp/some/path",
+				Path:       "/cnab/app/outputs/some-output",
 				Definition: "ParamOne",
 			},
 		},
@@ -232,7 +232,7 @@ func TestOpFromClaim(t *testing.T) {
 	is.Contains(op.Files, "/cnab/app/image-map.json")
 	is.Contains(op.Files, "/cnab/bundle.json")
 	is.Contains(op.Files, "/cnab/claim.json")
-	is.Contains(op.Outputs, "/tmp/some/path")
+	is.Contains(op.Outputs, "/cnab/app/outputs/some-output")
 
 	var imgMap map[string]bundle.Image
 	is.NoError(json.Unmarshal([]byte(op.Files["/cnab/app/image-map.json"]), &imgMap))
@@ -377,7 +377,7 @@ func TestOpFromClaim_NotApplicableToAction(t *testing.T) {
 
 	c.Bundle.Outputs = map[string]bundle.Output{
 		"some-output": {
-			Path:    "/path/to/some-output",
+			Path:    "/cnab/app/outputs/some-output",
 			ApplyTo: []string{"install"},
 		},
 	}
@@ -386,7 +386,7 @@ func TestOpFromClaim_NotApplicableToAction(t *testing.T) {
 		op, err := opFromClaim(stateful, c, invocImage, mockSet)
 		require.NoError(t, err)
 		gotOutputs := op.Outputs
-		assert.Contains(t, gotOutputs, "/path/to/some-output", "some-output should be listed in op.Outputs")
+		assert.Contains(t, gotOutputs, "/cnab/app/outputs/some-output", "some-output should be listed in op.Outputs")
 	})
 
 	t.Run("output not added to the operation when it doesn't apply to the action", func(t *testing.T) {
@@ -394,7 +394,7 @@ func TestOpFromClaim_NotApplicableToAction(t *testing.T) {
 		op, err := opFromClaim(stateful, c, invocImage, mockSet)
 		require.NoError(t, err)
 		gotOutputs := op.Outputs
-		assert.NotContains(t, gotOutputs, "/path/to/some-output", "some-output should not be listed in op.Outputs")
+		assert.NotContains(t, gotOutputs, "/cnab/app/outputs/some-output", "some-output should not be listed in op.Outputs")
 	})
 }
 
@@ -990,7 +990,8 @@ func TestGetOutputsGeneratedByAction(t *testing.T) {
 		},
 	}
 
-	gotOutputs := getOutputsGeneratedByAction("install", b)
+	gotOutputs, err := getOutputsGeneratedByAction("install", b)
+	require.NoError(t, err)
 	wantOutputs := map[string]string{
 		"/cnab/app/outputs/output1": "output1",
 		"/cnab/app/outputs/output2": "output2",
@@ -998,18 +999,35 @@ func TestGetOutputsGeneratedByAction(t *testing.T) {
 	}
 	assert.Equal(t, wantOutputs, gotOutputs)
 
-	gotOutputs = getOutputsGeneratedByAction("custom", b)
+	gotOutputs, err = getOutputsGeneratedByAction("custom", b)
+	require.NoError(t, err)
 	wantOutputs = map[string]string{
 		"/cnab/app/outputs/output2": "output2",
 	}
 	assert.Equal(t, wantOutputs, gotOutputs)
 
-	gotOutputs = getOutputsGeneratedByAction("upgrade", b)
+	gotOutputs, err = getOutputsGeneratedByAction("upgrade", b)
+	require.NoError(t, err)
 	wantOutputs = map[string]string{
 		"/cnab/app/outputs/output2": "output2",
 		"/cnab/app/outputs/output3": "output3",
 	}
 	assert.Equal(t, wantOutputs, gotOutputs)
+}
+
+func TestGetOutputsGeneratedByAction_RejectsTraversalPath(t *testing.T) {
+	b := bundle.Bundle{
+		Outputs: map[string]bundle.Output{
+			"output1": {
+				ApplyTo: []string{"install"},
+				Path:    "/cnab/app/outputs/../../../etc/shadow",
+			},
+		},
+	}
+
+	_, err := getOutputsGeneratedByAction("install", b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid path for output "output1"`)
 }
 
 func TestExpandCredentials(t *testing.T) {

--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -2,6 +2,8 @@ package bundle
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -40,10 +42,31 @@ func (b Bundle) IsOutputSensitive(outputName string) (bool, error) {
 	return false, fmt.Errorf("output %q not defined", outputName)
 }
 
+// outputsDir is the directory that CNAB output paths must live under, per
+// the CNAB spec.
+const outputsDir = "/cnab/app/outputs/"
+
+// ValidatePath checks that the Output's Path, if set, is a clean, absolute
+// path under the CNAB outputs directory. This rejects traversal segments
+// ("..") that would otherwise let a bundle read files outside the
+// designated outputs location.
+func (o Output) ValidatePath() error {
+	if o.Path != "" {
+		if path.Clean(o.Path) != o.Path || !strings.HasPrefix(o.Path, outputsDir) {
+			return fmt.Errorf("path %q must be a clean path under %q", o.Path, outputsDir)
+		}
+	}
+	return nil
+}
+
 // Validate an Output
 func (o *Output) Validate(name string, bun Bundle) error {
 	if o.Definition == "" {
 		return errors.New("output definition must be provided")
+	}
+
+	if err := o.ValidatePath(); err != nil {
+		return fmt.Errorf("output %q has invalid %s", name, err)
 	}
 
 	// Validate default against definition schema, if exists

--- a/bundle/outputs_test.go
+++ b/bundle/outputs_test.go
@@ -38,3 +38,52 @@ func TestOutputValidate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestOutputValidatePath(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+		err  string
+	}{
+		{
+			name: "empty path",
+			path: "",
+		},
+		{
+			name: "valid path",
+			path: "/cnab/app/outputs/foo",
+		},
+		{
+			name: "relative path traversal",
+			path: "../../../etc/passwd",
+			err:  `path "../../../etc/passwd" must be a clean path under "/cnab/app/outputs/"`,
+		},
+		{
+			name: "absolute path traversal",
+			path: "/cnab/app/outputs/../../../etc/shadow",
+			err:  `path "/cnab/app/outputs/../../../etc/shadow" must be a clean path under "/cnab/app/outputs/"`,
+		},
+		{
+			name: "not under outputs dir",
+			path: "/tmp/some/path",
+			err:  `path "/tmp/some/path" must be a clean path under "/cnab/app/outputs/"`,
+		},
+		{
+			name: "outputs dir itself, no suffix",
+			path: "/cnab/app/outputs",
+			err:  `path "/cnab/app/outputs" must be a clean path under "/cnab/app/outputs/"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := Output{Path: tc.path}
+			err := o.ValidatePath()
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}

--- a/driver/command/command.go
+++ b/driver/command/command.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/cnabio/cnab-go/driver"
@@ -144,18 +143,25 @@ func (d *Driver) getOperationResult(op *driver.Operation) (driver.OperationResul
 	opResult := driver.OperationResult{
 		Outputs: map[string]string{},
 	}
+	if len(op.Outputs) == 0 {
+		return opResult, nil
+	}
+
+	// Confine reads to the output directory, since outputPath comes from the
+	// untrusted bundle.json and could otherwise escape via ".." segments.
+	outputRoot, err := os.OpenRoot(d.outputDirName)
+	if err != nil {
+		return opResult, fmt.Errorf("Command driver (%s) failed opening output directory: %v", d.Name, err)
+	}
+	defer outputRoot.Close()
+
 	for outputPath, outputName := range op.Outputs {
-		fileName := path.Join(d.outputDirName, outputPath)
-		_, err := os.Stat(fileName)
+		relPath := strings.TrimPrefix(outputPath, "/")
+		contents, err := outputRoot.ReadFile(relPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return opResult, fmt.Errorf("Command driver (%s) failed checking for output file: %s Error: %v", d.Name, outputPath, err)
-		}
-
-		contents, err := ioutil.ReadFile(fileName)
-		if err != nil {
 			return opResult, fmt.Errorf("Command driver (%s) failed reading output file: %s Error: %v", d.Name, outputPath, err)
 		}
 

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cnabio/cnab-go/bundle"
 	"github.com/cnabio/cnab-go/bundle/definition"
@@ -144,5 +145,47 @@ func TestCommandDriverOutputs(t *testing.T) {
 			}, opResult.Outputs)
 		}
 		CreateAndRunTestCommandDriver(t, name, false, content, testfunc)
+	})
+
+	// GHSA-x74g-hj34-9579: a bundle-declared output path with traversal
+	// segments must not let the driver read files outside its own
+	// temporary output directory.
+	t.Run("output path traversal is rejected", func(t *testing.T) {
+		secret, err := os.CreateTemp("", "cnab-poc-secret")
+		require.NoError(t, err, "could not create secret file")
+		defer os.Remove(secret.Name())
+		_, err = secret.WriteString("TOP-SECRET-HOST-DATA")
+		require.NoError(t, err)
+		require.NoError(t, secret.Close())
+
+		traversalPaths := []string{
+			"/../../../../../../../.." + secret.Name(),
+			"../../../../../../../.." + secret.Name(),
+			"/cnab/app/outputs/../../../../../../../.." + secret.Name(),
+		}
+
+		// Create the conventional outputs directory structure, so the third
+		// (prefixed) traversal path actually walks through real directories
+		// on its way out, rather than failing early on a missing "cnab" dir.
+		content := `#!/bin/sh
+		mkdir -p "${CNAB_OUTPUT_DIR}/cnab/app/outputs"
+	`
+		name := "test-outputs-traversal.sh"
+		for _, traversalPath := range traversalPaths {
+			t.Run(traversalPath, func(t *testing.T) {
+				testfunc := func(cmddriver *Driver) {
+					if !cmddriver.CheckDriverExists() {
+						t.Fatalf("Expected driver %s to exist Driver Name %s ", name, cmddriver.Name)
+					}
+					op := buildOp()
+					op.Outputs = map[string]string{traversalPath: "leaked"}
+
+					opResult, err := cmddriver.Run(context.Background(), op)
+					assert.Error(t, err, "expected Run to reject a path-traversal output file")
+					assert.NotContains(t, opResult.Outputs, "leaked")
+				}
+				CreateAndRunTestCommandDriver(t, name, false, content, testfunc)
+			})
+		}
 	})
 }


### PR DESCRIPTION
## Summary
- Fixes GHSA-x74g-hj34-9579 (high, CWE-22/CWE-73): untrusted `outputs[*].path` from `bundle.json` let a malicious bundle read arbitrary files on the host running the command driver, via `path.Join(d.outputDirName, outputPath)` with no containment check.
- Confirmed the advisory's PoC is valid: reproduced it against `main` prior to this fix (host file contents leaked into `OperationResult.Outputs`), and confirmed the fix in GHSA-92c3-6gp6-45mv (kubernetes driver) does **not** cover this issue — it only touches `bundle.Location` (parameters/credentials), not `bundle.Output`, which has its own unvalidated `Path` field.
- `driver/command`: output reads are now confined to `d.outputDirName` via `os.Root`, blocking `..` traversal.
- `bundle`: new `Output.ValidatePath()` rejects paths that aren't clean, absolute paths under `/cnab/app/outputs/` (matches `schema/schema/bundle.schema.json`'s existing `^/cnab/app/outputs/.+$` pattern), used by `Output.Validate()`.
- `action`: `getOutputsGeneratedByAction` now calls `ValidatePath()` before adding an entry to `op.Outputs`, and returns an error (threaded through `opFromClaim`) since `action.Run` doesn't call `Bundle.Validate()` on the run path.
- No public API behavior changed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./driver/command/... ./bundle/... ./action/...`
- [x] `go test ./...` (full suite)
- [x] New tests: traversal payloads rejected + reads contained in `driver/command/command_nix_test.go`; `Output.ValidatePath()` cases in `bundle/outputs_test.go`; run-path rejection in `action/action_test.go`
- [x] Manually re-ran advisory PoC against patched code, confirmed rejection (exit 0, "not vulnerable")