### PR TITLE
fix(driver): avoid shell in CheckDriverExists

### DIFF
--- a/driver/command/command_nix.go
+++ b/driver/command/command_nix.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 )
@@ -16,7 +15,6 @@ func (d *Driver) CheckDriverExists() bool {
 		return err == nil
 	}
 
-	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("command -v %s", d.cmd()))
-	err := cmd.Run()
+	_, err := exec.LookPath(d.cmd())
 	return err == nil
 }

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -6,6 +6,7 @@ package command
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,30 @@ import (
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-go/driver"
 )
+
+// TestCheckDriverExists_NoShellInjection guards against GHSA-6pq9-97jw-vrmr:
+// a driver Name containing shell metacharacters must never be interpreted
+// by a shell.
+//
+// The temp dir must be all-lowercase: d.cmd() lowercases the whole Name
+// (including this embedded path) before use, so a mixed-case path (e.g.
+// from t.TempDir(), which embeds the test name) would check the wrong
+// path and mask the vulnerability.
+func TestCheckDriverExists_NoShellInjection(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "cnab-injection-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	marker := filepath.Join(tmp, "injected")
+
+	d := &Driver{Name: "x; touch " + marker + "; echo y"}
+	exists := d.CheckDriverExists()
+
+	assert.False(t, exists, "expected no driver to be found for the malicious name")
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr), "marker file must not have been created")
+}
 
 func TestCommandDriverOutputs(t *testing.T) {
 	buildOp := func() *driver.Operation {


### PR DESCRIPTION
## Summary
- `command.Driver.CheckDriverExists` ran `/bin/sh -c "command -v cnab-<Name>"`,
  interpolating the caller-supplied `Driver.Name` unquoted into a shell string.
- A `Name` containing shell metacharacters (`;`, `|`, `````, `$(...)`, etc.)
  executed as an additional shell command — reachable via
  `driver/lookup.Lookup(name)` with any unrecognized driver name.
- Replaced the shell probe with `exec.LookPath(d.cmd())`, which does the same
  PATH lookup without a shell, matching the existing Windows implementation
  (`exec.Command("where", d.cmd())`).

Fixes GHSA-6pq9-97jw-vrmr.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./driver/command/...` passes, including new
      `TestCheckDriverExists_NoShellInjection` regression test
- [x] Confirmed the new test fails against the pre-fix code (shell injection
      reproduced, marker file created) and passes against the fix
- [x] `go test ./...` full suite passes